### PR TITLE
refactor: make imports absolute

### DIFF
--- a/src/core/game.py
+++ b/src/core/game.py
@@ -9,7 +9,7 @@ from typing import Final
 
 import pygame as pg
 
-from .log_exception import log_exception
+from src.core import log_exception
 
 # set up logging
 lg.basicConfig(format="%(asctime)s [%(levelname)-8s] : %(filename)s:"

--- a/src/core/surfaces/scenes/game_scene/game_map.py
+++ b/src/core/surfaces/scenes/game_scene/game_map.py
@@ -2,17 +2,16 @@
 """Game map module for GameScene."""
 
 from __future__ import annotations
-from typing import Final
 
 import logging as lg
+from typing import Final
+
 import pygame as pg
 
-from ....game import simulat
-
-from ...surface import Surface
-from ....time_it import time_it
-
-from .tile import Tile, tiles_to_px
+from src.core.game import simulat
+from src.core.surfaces.scenes.game_scene.tile import Tile, tiles_to_px
+from src.core.surfaces.surface import Surface
+from src.core.time_it import time_it
 
 
 class GameMap(Surface):

--- a/src/core/surfaces/scenes/game_scene/game_scene.py
+++ b/src/core/surfaces/scenes/game_scene/game_scene.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
-from ..scene import Scene
-from .game_map import GameMap
+from src.core.surfaces.scenes.scene import Scene
+
+from src.core.surfaces.scenes.game_scene.game_map import GameMap
 
 
 class GameScene(Scene):

--- a/src/core/surfaces/scenes/scene.py
+++ b/src/core/surfaces/scenes/scene.py
@@ -6,7 +6,7 @@ import logging as lg
 
 import pygame as pg
 
-from ..surface import Surface
+from src.core.surfaces.surface import Surface
 
 
 class Scene:

--- a/src/core/surfaces/surface.py
+++ b/src/core/surfaces/surface.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import pygame as pg
 
-from ..game import simulat
+from src.core.game import simulat
 
 
 class Surface:

--- a/src/core/surfaces/topbar.py
+++ b/src/core/surfaces/topbar.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging as lg
 
-from .surface import Surface
+from src.core.surfaces.surface import Surface
 
 
 class Topbar(Surface):


### PR DESCRIPTION
## PR type (check all applicable)

- [ ] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [ ] `  chore   ` :ticket: chores
- [x] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Changes relative imports to absolute ones (`game.py`, `surface.py`, `topbar.py`, `scene.py`, `game_scene.py`, `game_map.py`)

## Related Tickets

- related issue #
- closes #9 

## Instructions, Screenshots

None