### PR TITLE
release: 0.3.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.analysis.typeCheckingMode": "basic",
+    "python.analysis.autoImportCompletions": true
+}

--- a/src/core/game.py
+++ b/src/core/game.py
@@ -44,6 +44,8 @@ class Simulat:
         # initialize clock
         self.clock = pg.time.Clock()
 
+        self.focused_surfaces: dict[Surface, bool] = {}
+
     def _init_next(self):
         """Initialize fonts and scene handling."""
         # initialize fonts
@@ -97,6 +99,10 @@ class Simulat:
 
             if keys[pg.K_ESCAPE]:
                 running = False
+
+            for surface in self.focused_surfaces:
+                if self.focused_surfaces[surface]:
+                    surface.input(keys)
 
             # draw scene
             self.scenes[self.active_scene].draw(self.screen)

--- a/src/core/game.py
+++ b/src/core/game.py
@@ -9,7 +9,7 @@ from typing import Final
 
 import pygame as pg
 
-from .log_exception import log_exception
+from src.core import log_exception
 
 # set up logging
 lg.basicConfig(format="%(asctime)s [%(levelname)-8s] : %(filename)s:"

--- a/src/core/game.py
+++ b/src/core/game.py
@@ -72,7 +72,7 @@ class Simulat:
         from .surfaces.scenes.game_scene.game_scene import GameScene
         from .surfaces.scenes.scene import Scene
 
-        self.scenes: dict[Scene] = {}
+        self.scenes: dict[str | None, Scene] = {}
         self.active_scene: str | None = "GameScene"  # GameScene is default
 
         # fallback scene

--- a/src/core/game.py
+++ b/src/core/game.py
@@ -87,6 +87,7 @@ class Simulat:
 
         self.logger.info("Starting main loop...")
         while running:
+            # PROCESS EVENTS / INPUT
             # check for window events
             for event in pg.event.get():
                 if event.type == pg.QUIT:
@@ -104,8 +105,13 @@ class Simulat:
                 if self.focused_surfaces[surface]:
                     surface.input(keys)
 
+            # UPDATE
+            # update scene
+            self.scenes[self.active_scene].update()
+
+            # RENDER
             # draw scene
-            self.scenes[self.active_scene].draw(self.screen)
+            self.scenes[self.active_scene].render(self.screen)
 
             # draw topbar
             self.screen.blit(self.topbar.surface, (0, 0))

--- a/src/core/game.py
+++ b/src/core/game.py
@@ -2,11 +2,12 @@
 """Game module for simulat."""
 
 from __future__ import annotations
+
+import logging as lg
+import sys
 from typing import Final
 
-import sys
 import pygame as pg
-import logging as lg
 
 from .log_exception import log_exception
 
@@ -68,8 +69,8 @@ class Simulat:
 
     def _init_scenes(self):
         """Initialize scenes."""
-        from .surfaces.scenes.scene import Scene
         from .surfaces.scenes.game_scene.game_scene import GameScene
+        from .surfaces.scenes.scene import Scene
 
         self.scenes: dict[Scene] = {}
         self.active_scene: str | None = "GameScene"  # GameScene is default

--- a/src/core/game.py
+++ b/src/core/game.py
@@ -2,6 +2,7 @@
 """Game module for simulat."""
 
 from __future__ import annotations
+from typing import Final
 
 import sys
 import pygame as pg
@@ -18,14 +19,14 @@ module_lg = lg.getLogger(__name__)
 module_lg.setLevel(lg.DEBUG)
 
 
-FPS: int = 60
-SIZE: tuple[int, int] = (1280, 720)
-
-
 class Simulat:
     """Main class for simulat."""
     def __init__(self):
         """Initialize pygame and the main window."""
+        # constants
+        self.FPS: Final = 60
+        self.SIZE: Final = (1280, 720)
+
         # set up logging
         self.logger = lg.getLogger(f"{__name__}.{type(self).__name__}")
         self.logger.info("Starting simulat...")
@@ -38,7 +39,7 @@ class Simulat:
         pg.init()
 
         # initialize screen
-        self.screen = pg.display.set_mode(SIZE)
+        self.screen = pg.display.set_mode(self.SIZE)
 
         # initialize clock
         self.clock = pg.time.Clock()
@@ -107,7 +108,7 @@ class Simulat:
             pg.display.flip()
 
             # limit framerate
-            self.clock.tick(FPS)
+            self.clock.tick(self.FPS)
 
         # quit pygame
         self.logger.info("Quit event received, exiting.")

--- a/src/core/surfaces/scenes/game_scene/game_map.py
+++ b/src/core/surfaces/scenes/game_scene/game_map.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Final
 
 import logging as lg
+import pygame as pg
 
 from ....game import simulat
 
@@ -34,14 +35,40 @@ class GameMap(Surface):
             tiles_to_px(self.MAP_SIZE[1])
         )
 
+        self.camera = pg.Rect((0, 0), self.surface_size)
+
         self.logger.debug(f"Game map size: {self.MAP_SIZE} tiles, "
                           f"{self.surface_size} px")
 
         # initialize surface
         super().__init__(self.surface_size)
+        simulat.focused_surfaces[self] = True
 
         # initialize tiles
         self._init_tiles()
+
+    def input(self, key: pg.key) -> None:
+        """Handle input events."""
+        if key[pg.K_UP]:
+            self.camera.y -= tiles_to_px(0.5)
+        if key[pg.K_DOWN]:
+            self.camera.y += tiles_to_px(0.5)
+        if key[pg.K_LEFT]:
+            self.camera.x -= tiles_to_px(0.5)
+        if key[pg.K_RIGHT]:
+            self.camera.x += tiles_to_px(0.5)
+
+        self._update_camera_pos()
+
+    def update(self) -> None:
+        self._update_camera_pos()
+
+    def _update_camera_pos(self) -> None:
+        """Update the camera position."""
+        self.camera.x = min(max(self.camera.x, 0),
+                            self.surface_size[0] - simulat.SIZE[0])
+        self.camera.y = min(max(self.camera.y, 0),
+                            self.surface_size[1] - simulat.SIZE[1])
 
     @time_it
     def _init_tiles(self):

--- a/src/core/surfaces/scenes/game_scene/game_map.py
+++ b/src/core/surfaces/scenes/game_scene/game_map.py
@@ -6,10 +6,12 @@ from typing import Final
 
 import logging as lg
 
+from ....game import simulat
+
 from ...surface import Surface
 from ....time_it import time_it
 
-from .tile import Tile, TILE_SIZE
+from .tile import Tile, tiles_to_px
 
 
 class GameMap(Surface):
@@ -28,8 +30,8 @@ class GameMap(Surface):
         self.MAP_SIZE: Final = (40, 40)  # tiles
 
         self.surface_size = (
-            TILE_SIZE * self.MAP_SIZE[0],
-            TILE_SIZE * self.MAP_SIZE[1]
+            tiles_to_px(self.MAP_SIZE[0]),
+            tiles_to_px(self.MAP_SIZE[1])
         )
 
         self.logger.debug(f"Game map size: {self.MAP_SIZE} tiles, "

--- a/src/core/surfaces/scenes/game_scene/game_map.py
+++ b/src/core/surfaces/scenes/game_scene/game_map.py
@@ -9,7 +9,7 @@ import logging as lg
 from ...surface import Surface
 from ....time_it import time_it
 
-from .tile import Tile
+from .tile import Tile, TILE_SIZE
 
 
 class GameMap(Surface):
@@ -25,12 +25,11 @@ class GameMap(Surface):
 
         self.logger.debug("Initializing game map surface...")
 
-        self.TILE_SIZE: Final = 32  # pixels
         self.MAP_SIZE: Final = (40, 40)  # tiles
 
         self.surface_size = (
-            self.TILE_SIZE * self.MAP_SIZE[0],
-            self.TILE_SIZE * self.MAP_SIZE[1]
+            TILE_SIZE * self.MAP_SIZE[0],
+            TILE_SIZE * self.MAP_SIZE[1]
         )
 
         self.logger.debug(f"Game map size: {self.MAP_SIZE} tiles, "

--- a/src/core/surfaces/scenes/game_scene/game_map.py
+++ b/src/core/surfaces/scenes/game_scene/game_map.py
@@ -28,7 +28,7 @@ class GameMap(Surface):
 
         self.logger.debug("Initializing game map surface...")
 
-        self.MAP_SIZE: Final = (40, 40)  # tiles
+        self.MAP_SIZE: Final = (80, 80)  # tiles
 
         self.surface_size = (
             tiles_to_px(self.MAP_SIZE[0]),

--- a/src/core/surfaces/scenes/game_scene/game_map.py
+++ b/src/core/surfaces/scenes/game_scene/game_map.py
@@ -19,7 +19,7 @@ class GameMap(Surface):
     tiles (see `Tile` class) that can be walls, floors, doors, etc. The game
     map is a subsurface of the game scene.
     """
-    def __init__(self, scene: GameScene) -> None:
+    def __init__(self) -> None:
         """Initialize the game map."""
         self.logger = lg.getLogger(f"{__name__}.{type(self).__name__}")
 

--- a/src/core/surfaces/scenes/game_scene/game_map.py
+++ b/src/core/surfaces/scenes/game_scene/game_map.py
@@ -47,7 +47,7 @@ class GameMap(Surface):
         # initialize tiles
         self._init_tiles()
 
-    def input(self, key: pg.key) -> None:
+    def input(self, key: ScancodeWrapper) -> None:
         """Handle input events."""
         if key[pg.K_UP]:
             self.camera.y -= tiles_to_px(0.5)

--- a/src/core/surfaces/scenes/game_scene/game_map.py
+++ b/src/core/surfaces/scenes/game_scene/game_map.py
@@ -2,17 +2,16 @@
 """Game map module for GameScene."""
 
 from __future__ import annotations
-from typing import Final
 
 import logging as lg
+from typing import Final
+
 import pygame as pg
 
-from ....game import simulat
-
-from ...surface import Surface
-from ....time_it import time_it
-
-from .tile import Tile, tiles_to_px
+from src.core.game import simulat
+from src.core.surfaces.scenes.game_scene.tile import Tile, tiles_to_px
+from src.core.surfaces.surface import Surface
+from src.core.time_it import time_it
 
 
 class GameMap(Surface):

--- a/src/core/surfaces/scenes/game_scene/game_scene.py
+++ b/src/core/surfaces/scenes/game_scene/game_scene.py
@@ -21,6 +21,5 @@ class GameScene(Scene):
         super().__init__()
 
         # initialize map
-        self.game_map = GameMap(self)
+        self.game_map = GameMap()
         self.surface.blit(self.game_map.surface, self.game_map.pos)
-

--- a/src/core/surfaces/scenes/game_scene/game_scene.py
+++ b/src/core/surfaces/scenes/game_scene/game_scene.py
@@ -29,5 +29,6 @@ class GameScene(Scene):
         self.surface.blit(
             self.game_map.surface,
             (0, 0),
+            self.game_map.camera
         )
         self.draw(dest)

--- a/src/core/surfaces/scenes/game_scene/game_scene.py
+++ b/src/core/surfaces/scenes/game_scene/game_scene.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
-from ..scene import Scene
-from .game_map import GameMap
+from src.core.surfaces.scenes.scene import Scene
+
+from src.core.surfaces.scenes.game_scene.game_map import GameMap
 
 
 class GameScene(Scene):

--- a/src/core/surfaces/scenes/game_scene/game_scene.py
+++ b/src/core/surfaces/scenes/game_scene/game_scene.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from ..scene import Scene
-
 from .game_map import GameMap
 
 
@@ -21,4 +20,14 @@ class GameScene(Scene):
 
         # initialize map
         self.game_map = GameMap()
-        self.surface.blit(self.game_map.surface, self.game_map.pos)
+
+    def update(self) -> None:
+        """Update the game scene."""
+        self.game_map.update()
+
+    def render(self, dest) -> None:
+        self.surface.blit(
+            self.game_map.surface,
+            (0, 0),
+        )
+        self.draw(dest)

--- a/src/core/surfaces/scenes/game_scene/game_scene.py
+++ b/src/core/surfaces/scenes/game_scene/game_scene.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from ..scene import Scene
-from ....game import simulat
 
 from .game_map import GameMap
 

--- a/src/core/surfaces/scenes/game_scene/tile.py
+++ b/src/core/surfaces/scenes/game_scene/tile.py
@@ -2,8 +2,12 @@
 """Tile module for GameMap."""
 
 from __future__ import annotations
+from typing import Final
 
 import logging as lg
+
+
+TILE_SIZE: Final = 32  # pixels
 
 
 class Tile():
@@ -20,11 +24,11 @@ class Tile():
         self.pos_y = pos[1]
 
         self.px_pos = (
-            self.pos_x * self.game_map.TILE_SIZE,
-            self.pos_y * self.game_map.TILE_SIZE
+            self.pos_x * TILE_SIZE,
+            self.pos_y * TILE_SIZE
         )
 
-        self.size = self.game_map.TILE_SIZE
+        self.size = TILE_SIZE
         self.width = self.size
         self.height = self.size
 

--- a/src/core/surfaces/scenes/game_scene/tile.py
+++ b/src/core/surfaces/scenes/game_scene/tile.py
@@ -58,9 +58,9 @@ class Tile():
         self.game_map.blit(self.surface.surface, self.surface.pos)
 
 
-def tiles_to_px(tiles: int) -> int:
+def tiles_to_px(tiles: int | float) -> int:
     """Convert tiles to pixels."""
-    return tiles * TILE_SIZE
+    return round(tiles * TILE_SIZE)
 
 
 def px_to_tiles(px: int) -> int:

--- a/src/core/surfaces/scenes/game_scene/tile.py
+++ b/src/core/surfaces/scenes/game_scene/tile.py
@@ -56,3 +56,16 @@ class Tile():
         https://www.pygame.org/docs/ref/surface.html#pygame.Surface.subsurface).
         """
         self.game_map.blit(self.surface.surface, self.surface.pos)
+
+
+def tiles_to_px(tiles: int) -> int:
+    """Convert tiles to pixels."""
+    return tiles * TILE_SIZE
+
+
+def px_to_tiles(px: int) -> int:
+    """Convert pixels to tiles."""
+    if px % TILE_SIZE != 0:
+        raise ValueError(f"px ({px}) is not a multiple of TILE_SIZE "
+                         f"({TILE_SIZE})")
+    return px // TILE_SIZE

--- a/src/core/surfaces/scenes/game_scene/tile.py
+++ b/src/core/surfaces/scenes/game_scene/tile.py
@@ -47,5 +47,8 @@ class Tile():
         return f"{type(self).__name__} at {self.pos}"
 
     def draw(self):
-        """Draw the tile."""
+        """Draw the tile. NOTE: this method is not used. The tiles are drawn
+        directly on the game map. (see
+        https://www.pygame.org/docs/ref/surface.html#pygame.Surface.subsurface).
+        """
         self.game_map.blit(self.surface.surface, self.surface.pos)

--- a/src/core/surfaces/scenes/game_scene/tile.py
+++ b/src/core/surfaces/scenes/game_scene/tile.py
@@ -38,6 +38,14 @@ class Tile():
         self.surface.fill((self.pos_x * 16 % 255, self.pos_y * 16 % 255,
                            (self.pos_x + self.pos_y) * 8 % 255))
 
+    def __repr__(self) -> str:
+        """Return a string representation of the tile."""
+        return f"{type(self).__name__}({self.pos})"
+
+    def __str__(self) -> str:
+        """Return a user-friendly representation of the tile."""
+        return f"{type(self).__name__} at {self.pos}"
+
     def draw(self):
         """Draw the tile."""
         self.game_map.blit(self.surface.surface, self.surface.pos)

--- a/src/core/surfaces/scenes/game_scene/tile.py
+++ b/src/core/surfaces/scenes/game_scene/tile.py
@@ -2,9 +2,9 @@
 """Tile module for GameMap."""
 
 from __future__ import annotations
-from typing import Final
 
 import logging as lg
+from typing import Final
 
 
 TILE_SIZE: Final = 32  # pixels

--- a/src/core/surfaces/scenes/scene.py
+++ b/src/core/surfaces/scenes/scene.py
@@ -6,7 +6,7 @@ import logging as lg
 
 import pygame as pg
 
-from ..surface import Surface
+from src.core.surfaces.surface import Surface
 
 
 class Scene:

--- a/src/core/surfaces/scenes/scene.py
+++ b/src/core/surfaces/scenes/scene.py
@@ -41,6 +41,14 @@ class Scene:
                 (255, 0, 0)
             )
 
+    def update(self) -> None:
+        """Update the scene."""
+        pass
+
+    def render(self, dest) -> None:
+        """Render the scene."""
+        self.draw(dest)
+
     def draw(self, screen: pg.Surface):
         """Draw the scene to the screen."""
         screen.blit(self.surface.surface, self.surface.pos)

--- a/src/core/surfaces/scenes/scene.py
+++ b/src/core/surfaces/scenes/scene.py
@@ -2,8 +2,9 @@
 """Scene module for simulat."""
 from __future__ import annotations
 
-import pygame as pg
 import logging as lg
+
+import pygame as pg
 
 from ..surface import Surface
 

--- a/src/core/surfaces/scenes/scene.py
+++ b/src/core/surfaces/scenes/scene.py
@@ -18,14 +18,14 @@ class Scene:
     """
     def __init__(self) -> None:
         """Initialize the scene."""
-        from ...game import simulat, SIZE
+        from ...game import simulat
         self.id = type(self).__name__
 
         self.logger = lg.getLogger(f"{__name__}.{self.id}")
 
         self.logger.debug(f"Initializing scene {self.id}...")
         self.surface = Surface(
-            (SIZE[0], SIZE[1] - simulat.topbar.height),
+            (simulat.SIZE[0], simulat.SIZE[1] - simulat.topbar.height),
             (0, simulat.topbar.height)
         )
 

--- a/src/core/surfaces/surface.py
+++ b/src/core/surfaces/surface.py
@@ -74,7 +74,7 @@ class Surface:
         return self.surface.convert(surface)
 
     def blit(self, source: pg.Surface, dest: tuple[int, int],
-             area: tuple[int, int, int, int] | None = None,
+             area: tuple[int, int, int, int] | pg.Rect | None = None,
              special_flags: int = 0):
         """Draw one surface onto another.
 

--- a/src/core/surfaces/surface.py
+++ b/src/core/surfaces/surface.py
@@ -2,7 +2,6 @@
 """Surface module for simulat."""
 
 from __future__ import annotations
-from typing import overload
 
 import pygame as pg
 

--- a/src/core/surfaces/surface.py
+++ b/src/core/surfaces/surface.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import pygame as pg
 
-from ..game import simulat
+from src.core.game import simulat
 
 
 class Surface:

--- a/src/core/surfaces/topbar.py
+++ b/src/core/surfaces/topbar.py
@@ -31,15 +31,15 @@ class Topbar(Surface):
     def _init_sub_surfaces(self):
         self.debug_surface = self.subsurface(
             (0, 0),
-            (self.width * 0.3, self.height)
+            (round(self.width * 0.3), self.height)
         )
         self.title_surface = self.subsurface(
-            (self.width * 0.3, 0),
-            (self.width * 0.4, self.height)
+            (round(self.width * 0.3), 0),
+            (round(self.width * 0.4), self.height)
         )
         self.details_surface = self.subsurface(
-            (self.width * 0.7, 0),
-            (self.width * 0.3, self.height)
+            (round(self.width * 0.7), 0),
+            (round(self.width * 0.3), self.height)
         )
 
         self.debug_surface.fill((255, 0, 0))

--- a/src/core/surfaces/topbar.py
+++ b/src/core/surfaces/topbar.py
@@ -2,6 +2,7 @@
 """Topbar module for simulat."""
 
 from __future__ import annotations
+
 import logging as lg
 
 from .surface import Surface

--- a/src/core/surfaces/topbar.py
+++ b/src/core/surfaces/topbar.py
@@ -9,11 +9,11 @@ from .surface import Surface
 
 class Topbar(Surface):
     def __init__(self):
-        from ..game import SIZE
+        from ..game import simulat
         self.logger = lg.getLogger(f"{__name__}.{type(self).__name__}")
         self.logger.debug("Initializing topbar...")
 
-        super().__init__((SIZE[0], 24), (0, 0))
+        super().__init__((simulat.SIZE[0], 24), (0, 0))
 
         # init sub-surfaces
         self._init_sub_surfaces()

--- a/src/core/surfaces/topbar.py
+++ b/src/core/surfaces/topbar.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging as lg
 
-from .surface import Surface
+from src.core.surfaces.surface import Surface
 
 
 class Topbar(Surface):

--- a/src/core/time_it.py
+++ b/src/core/time_it.py
@@ -2,10 +2,10 @@
 """Timing decorator."""
 
 from __future__ import annotations
-from functools import wraps
 
 import logging as lg
 import time as t
+from functools import wraps
 
 
 def time_it(func):


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [x] `   fix    ` :bug: bugfixes
- [x] `  chore   ` :ticket: chores
- [x] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [x] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [x] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Adds the ability to move the camera through the game map using the arrow keys.
- Enlarges the map from `40x40` to `80x80` tiles.
- **Moves the `FPS` and `SIZE` constants from global namespace to the `Simulat` class.**
- Removes an unnecesarry imports from `surface.py`, `game_scene.py`.
- Adds `tiles ⇄ pixels` conversion methods to the `Tile` class.
- Adds the `update()` and `render()` methods to the `Scene` class. The methods are called while the scene is active.
- Adds the `Simulat.focused_surfaces` dict (structure `Surface: bool`). The input caught in the `Simulat.keys` variable will be sent to the surface (call `Surface.input(keys)`).
- Moves the `blit` call into `GameScene.render()` method.
- Removes unneeded arguments to the `GameMap` class constructor.
- Fixes multiple wrongly-typed variables (`game.py`, `game_map.py`, `surface.py`).
- Organizes imports according to the PEP 8 convention.
- Changes relative imports to absolute ones (`game.py`, `surface.py`, `topbar.py`, `scene.py`, `game_scene.py`, `game_map.py`)

## Related Tickets

- related issue #8 #9 #10 
- closes #

## Instructions, Screenshots

![Simulat's camera in action.](https://github.com/pufereq/simulat/assets/94570596/d3a36ad6-0b84-418e-b6ea-8a646e907703)
