### PR TITLE
feat: untie movement from framerate

### DIFF
--- a/src/simulat/core/characters/character.py
+++ b/src/simulat/core/characters/character.py
@@ -61,17 +61,27 @@ class Character:
             0
         )
 
-    def update(self) -> None:
-        """Update the character."""
-        self.px_pos = (tiles_to_px(self.pos[0]), tiles_to_px(self.pos[1]))
-        self.rect.center = self.px_pos
-        self.speed = min(self.max_speed, self.speed + 1)
+    def update(self, delta: float) -> None:
+        """Update the character.
+
+        Args:
+            delta (float): Time passed since the last update (in seconds).
+        """
         self.move(
-            self.velocity[0] * self.max_speed,
-            self.velocity[1] * self.max_speed
+            self.velocity[0] * self.max_speed * delta,
+            self.velocity[1] * self.max_speed * delta
         )
+
+        # update px position
+        self.px_pos = [tiles_to_px(self.pos[0]), tiles_to_px(self.pos[1])]
+        self.rect.center = self.px_pos
+
+        # cap position
+        self._cap_position()
+
+        # update tile position
         self.px_pos = self.rect.center
-        self.pos = (px_to_tiles(self.px_pos[0]), px_to_tiles(self.px_pos[1]))
+        self.pos = [px_to_tiles(self.px_pos[0]), px_to_tiles(self.px_pos[1])]
 
     def render(self) -> None:
         """Render the character."""

--- a/src/simulat/core/characters/character.py
+++ b/src/simulat/core/characters/character.py
@@ -84,10 +84,7 @@ class Character:
 
     def render(self) -> None:
         """Render the character."""
-        from src.simulat.core.game import simulat
-        # self.sprite.fill((255, 0, 0))
         self.game_map.blit(self.sprite.surface, self.rect)
-        simulat.topbar.update_title(f"Character position: {self.pos}")
 
     def move(self, dx: float, dy: float) -> None:
         """Move the character.

--- a/src/simulat/core/characters/character.py
+++ b/src/simulat/core/characters/character.py
@@ -93,22 +93,16 @@ class Character:
         """Move the character.
 
         Args:
-            dx (float): Horizontal distance to move.
-            dy (float): Vertical distance to move.
+            dx (float): Horizontal distance to move (in tiles).
+            dy (float): Vertical distance to move (in tiles).
         """
 
         # move horizontally
         if dx != 0:
-            self.px_pos[0] += dx
-            self.px_pos[0] = max(0, min(self.game_map.MAP_SIZE[0] - 1,
-                                        self.px_pos[0]))
+            self.pos[0] += dx
             self.velocity[0] = 0
 
         # move vertically
         if dy != 0:
-            self.px_pos[1] += dy
-            self.px_pos[1] = max(0, min(self.game_map.MAP_SIZE[1] - 1,
-                                        self.px_pos[1]))
+            self.pos[1] += dy
             self.velocity[1] = 0
-
-        self.speed = 0

--- a/src/simulat/core/characters/character.py
+++ b/src/simulat/core/characters/character.py
@@ -33,11 +33,10 @@ class Character:
         self.last_name = "Doe"
         self.name = f"{self.first_name} {self.last_name}"
 
-        self.pos: tuple[float, float] = pos
-        self.px_pos: tuple[int, int] = (tiles_to_px(pos[0]),
-                                        tiles_to_px(pos[1]))
-        self.max_speed: float = 16
-        self.speed: float = 0
+        self.pos: list[float] = list(pos)  # position in tiles
+        self.px_pos: list[int] = [tiles_to_px(pos[0]), tiles_to_px(pos[1])]
+
+        self.max_speed: float = 4  # tiles per second
 
         self.velocity: list[float] = [0, 0]
 

--- a/src/simulat/core/characters/player.py
+++ b/src/simulat/core/characters/player.py
@@ -22,3 +22,10 @@ class Player(Character):
 
         self.logger.debug("Initializing player...")
         super().__init__(game_map, pos)
+
+    def render(self) -> None:
+        from src.simulat.core.game import simulat
+        simulat.topbar.update_title(
+            f"XY: {self.pos[0]:.3f}, {self.pos[1]:.3f}"
+        )
+        return super().render()

--- a/src/simulat/core/game.py
+++ b/src/simulat/core/game.py
@@ -85,6 +85,7 @@ class Simulat:
 
     def run(self):
         running: bool = True
+        self.frame_delta: float = 1  # this avoids exceptions on first frame
 
         self.logger.info("Starting main loop...")
         while running:
@@ -121,7 +122,7 @@ class Simulat:
             pg.display.flip()
 
             # limit framerate
-            self.clock.tick(self.FPS)
+            self.frame_delta = self.clock.tick(self.FPS) * .001  # in seconds
 
         # quit pygame
         self.logger.info("Quit event received, exiting.")

--- a/src/simulat/core/game.py
+++ b/src/simulat/core/game.py
@@ -109,7 +109,7 @@ class Simulat:
 
             # UPDATE
             # update scene
-            self.scenes[self.active_scene].update()
+            self.scenes[self.active_scene].update(self.frame_delta)
 
             # RENDER
             # draw scene

--- a/src/simulat/core/surfaces/game_map/game_map.py
+++ b/src/simulat/core/surfaces/game_map/game_map.py
@@ -66,10 +66,10 @@ class GameMap(Surface):
         if key[pg.K_RIGHT]:
             self.player.velocity[0] += 1
 
-    def update(self) -> None:
+    def update(self, delta: float) -> None:
         """Update the game map."""
         self.camera.update()
-        self.player.update()
+        self.player.update(delta)
 
     def render(self) -> None:
         """Render the game map."""

--- a/src/simulat/core/surfaces/scenes/game_scene/game_scene.py
+++ b/src/simulat/core/surfaces/scenes/game_scene/game_scene.py
@@ -22,9 +22,13 @@ class GameScene(Scene):
         # initialize map
         self.game_map = GameMap()
 
-    def update(self) -> None:
-        """Update the game scene."""
-        self.game_map.update()
+    def update(self, delta: float) -> None:
+        """Update the game scene.
+
+        Args:
+            delta (float): The time passed since the last frame.
+        """
+        self.game_map.update(delta)
 
     def render(self, dest) -> None:
         self.surface.blit(

--- a/src/simulat/core/surfaces/scenes/scene.py
+++ b/src/simulat/core/surfaces/scenes/scene.py
@@ -43,8 +43,12 @@ class Scene:
                 (255, 0, 0)
             )
 
-    def update(self) -> None:
-        """Update the scene."""
+    def update(self, delta: float) -> None:
+        """Update the scene.
+
+        Args:
+            delta (float): The time passed since the last frame.
+        """
         pass
 
     def render(self, dest) -> None:


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [x] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Adds a `Simulat.frame_delta` variable, which is set by `Simulat.clock.tick()` method.
- Change `Character.pos` unit to tiles (from px).
- Change `Character.max_speed` unit to tiles/second (TiPS)
- Adds `delta` argument to `Scene.update()`, `GameScene.update()`, `GameMap.update()`, `Character.update()` methods.
- Modifies `Character.update()` method to multiply the velocity and max speed by the delta speed.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

An example of moving to the left at 4 Tiles per Second

10 FPS
![10fps](https://github.com/pufereq/simulat/assets/94570596/167e5c6e-34ad-4f3e-9375-18c9a98db935)

30 FPS
![30fps](https://github.com/pufereq/simulat/assets/94570596/96dacc43-b05f-4369-bea7-be6f05dc8574)

60 FPS
![60fps](https://github.com/pufereq/simulat/assets/94570596/e8c33cc6-ff97-4713-86f0-5b04c8be646d)

_I wasn't able to synchronize the videos correctly, but it shows the idea._
