### PR TITLE
feat: add map layout

### DIFF
--- a/src/simulat/core/surfaces/game_map/game_map.py
+++ b/src/simulat/core/surfaces/game_map/game_map.py
@@ -7,13 +7,14 @@ import logging as lg
 from typing import Final
 
 import pygame as pg
-from src.simulat.core.characters.player import Player
 
+from src.simulat.core.characters.player import Player
 from src.simulat.core.game import simulat
 from src.simulat.core.surfaces.game_map.camera import Camera
 from src.simulat.core.surfaces.game_map.tiles.tile import Tile, tiles_to_px
 from src.simulat.core.surfaces.surface import Surface
 from src.simulat.core.time_it import time_it
+from src.simulat.data.map_layout import MapLayout
 
 
 class GameMap(Surface):
@@ -29,7 +30,9 @@ class GameMap(Surface):
 
         self.logger.debug("Initializing game map surface...")
 
-        self.MAP_SIZE: Final = (80, 80)  # tiles
+        # self.MAP_SIZE: Final = (80, 80)  # tiles
+        self.MAP_SIZE: Final = (len(MapLayout.get_map_layout()[0]),
+                                len(MapLayout.get_map_layout()))
 
         self.surface_size = (
             tiles_to_px(self.MAP_SIZE[0]),
@@ -83,8 +86,14 @@ class GameMap(Surface):
     def _init_tiles(self):
         """Initialize the map tiles."""
         self.tiles = []
-        for y in range(self.MAP_SIZE[1]):
+        self.collider_tiles = []
+
+        for y, row in enumerate(MapLayout.get_map_layout()):
             self.tiles.append([])
-            for x in range(self.MAP_SIZE[0]):
-                self.tiles[y].append(Tile(self, (x, y)))
+            for x, char in enumerate(row):
+                self.tiles[y].append(
+                    MapLayout.get_tile_from_char(char)(self, (x, y))
+                )
                 self.tiles[y][x].draw()
+                if self.tiles[y][x].is_collider:
+                    self.collider_tiles.append(self.tiles[y][x])

--- a/src/simulat/data/map_layout.py
+++ b/src/simulat/data/map_layout.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+"""Map layout module."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from src.simulat.core.surfaces.game_map.tiles.collider_tiles.collider_tile \
+    import ColliderTile
+from src.simulat.core.surfaces.game_map.tiles.tile import Tile
+
+
+class MapLayout:
+    """Map layout class.
+
+    The map layout class contains the layout of the game map. It is a 2D list
+    of strings, where each string represents a tile type. The map layout is
+    used to generate the game map.
+
+    Character meanings:
+    -
+
+    Attributes:
+        MAP_LAYOUT (Final): The map layout.
+    """
+    CHAR_TO_TILE: Final = {
+        "w": ColliderTile,
+        " ": Tile
+    }
+
+    MAP_LAYOUT: Final[str] = """\
+wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww
+w              w                                                               w
+w             w                                                                w
+w       wwwwww                                                                 w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+w                                                                              w
+wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww
+"""
+
+    @staticmethod
+    def get_map_layout() -> list[list[str]]:
+        """Return the map layout as a 2D list of strings.
+
+        Returns:
+            list[list[str]]: The map layout.
+        """
+        return [list(row) for row in MapLayout.MAP_LAYOUT.split("\n") if row]
+
+    @staticmethod
+    def get_tile_char_at(x: int, y: int) -> str:
+        """Return the char tile at the given coordinates.
+
+        Args:
+            x (int): The x coordinate.
+            y (int): The y coordinate.
+
+        Returns:
+            str: The tile char.
+        """
+        return MapLayout.get_map_layout()[y][x]
+
+    @staticmethod
+    def get_tile(x: int, y: int):
+        """Return the tile at the given coordinates.
+
+        Args:
+            x (int): The x coordinate.
+            y (int): The y coordinate.
+
+        Returns:
+            str: The tile.
+        """
+        y = round(y)
+        x = round(x)
+        return MapLayout.CHAR_TO_TILE[MapLayout.get_tile_char_at(x, y)]
+
+    @staticmethod
+    def get_tile_from_char(char: str):
+        """Return the tile by char.
+
+        Args:
+            char (str): The tile char.
+
+        Returns:
+            The tile class.
+        """
+        return MapLayout.CHAR_TO_TILE[char]


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [x] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Adds the `MapLayout` class which contains the layout, the char-to-tile assignment dict and some utility methods.
- Modifies the `GameMap` class to use the layout.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

A part of the map layout and the rendered map.

```
wwwwwwwwwwwwwwwwwww
w              w   
w             w    
w       wwwwww     
w                  
w                  
w                  
w                  
```

![A screenshot of the map](https://github.com/pufereq/simulat/assets/94570596/8814d129-6b10-4e03-8bb7-aa26049d7395)

