### PR TITLE
feat: add decorative tiles

### DIFF
--- a/src/simulat/core/surfaces/game_map/tiles/decorative_tiles/decorative_tile.py
+++ b/src/simulat/core/surfaces/game_map/tiles/decorative_tiles/decorative_tile.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""Decorative tile baseclass module."""
+
+from __future__ import annotations
+
+from src.simulat.core.surfaces.game_map.tiles.tile import Tile
+
+
+class DecorativeTile(Tile):
+    """Decorative tile class.
+
+    A decorative tile is a tile that is purely decorative and has no collision.
+    It inherits from `Tile`.
+    """
+
+    def __init__(self, game_map: GameMap, pos: tuple[int, int]) -> None:
+        """Initialize the decorative tile."""
+        super().__init__(game_map, pos)
+
+        self.name = "Decorative Tile"
+
+        self.is_collider = False
+
+    def draw(self) -> None:
+        """Draw the decorative tile."""
+        self.surface.fill((10, 128, 10))
+        super().draw()

--- a/src/simulat/data/map_layout.py
+++ b/src/simulat/data/map_layout.py
@@ -33,9 +33,9 @@ class MapLayout:
 
     MAP_LAYOUT: Final[str] = """\
 wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww
-w              w                                                               w
-w             w                                                                w
-w       wwwwww                                                                 w
+wggggggggggggggw                                                               w
+wgggggggggggggw                                                                w
+wgggggggwwwwww                                                                 w
 w                                                                              w
 w                                                                              w
 w                                                                              w

--- a/src/simulat/data/map_layout.py
+++ b/src/simulat/data/map_layout.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 from typing import Final
+from src.simulat.core.surfaces.game_map.tiles.decorative_tiles. \
+    decorative_tile import DecorativeTile
 
 from src.simulat.core.surfaces.game_map.tiles.collider_tiles.collider_tile \
     import ColliderTile
@@ -25,6 +27,7 @@ class MapLayout:
     """
     CHAR_TO_TILE: Final = {
         "w": ColliderTile,
+        "g": DecorativeTile,
         " ": Tile
     }
 


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [x] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Adds a `DecorativeTile` class.
- Assigns `g` character to `DecorativeTile` in map layout.
- Changes map layout to include some decorative tiles.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

![A screenshot showing the new decorative tiles](https://github.com/pufereq/simulat/assets/94570596/b198b8be-7bea-4b08-826c-44381552265b)
