### PR TITLE
feat: add sidebar

### DIFF
--- a/src/simulat/core/surfaces/game_map/camera.py
+++ b/src/simulat/core/surfaces/game_map/camera.py
@@ -29,7 +29,7 @@ class Camera():
 
         self.game_map = game_map
 
-        self.rect = pg.Rect((0, 0), (simulat.SIZE[0], simulat.SIZE[1] - simulat.topbar.height))
+        self.rect = pg.Rect((0, 0), self.game_map.display_size)
 
         self.speed: int = tiles_to_px(0.25)
         self.actual_speed: float = 0

--- a/src/simulat/core/surfaces/game_map/game_map.py
+++ b/src/simulat/core/surfaces/game_map/game_map.py
@@ -24,11 +24,13 @@ class GameMap(Surface):
     tiles (see `Tile` class) that can be walls, floors, doors, etc. The game
     map is a subsurface of the game scene.
     """
-    def __init__(self) -> None:
+    def __init__(self, scene: Scene) -> None:
         """Initialize the game map."""
         self.logger = lg.getLogger(f"{__name__}.{type(self).__name__}")
 
         self.logger.debug("Initializing game map surface...")
+
+        self.scene = scene
 
         # self.MAP_SIZE: Final = (80, 80)  # tiles
         self.MAP_SIZE: Final = (len(MapLayout.get_map_layout()[0]),
@@ -37,6 +39,11 @@ class GameMap(Surface):
         self.surface_size = (
             tiles_to_px(self.MAP_SIZE[0]),
             tiles_to_px(self.MAP_SIZE[1])
+        )
+
+        self.display_size: tuple = (
+            scene.size[0] - scene.sidebar.SIDEBAR_SIZE[0],
+            scene.size[1]
         )
 
         self.player = Player(self, (9, 9))

--- a/src/simulat/core/surfaces/game_map/game_map.py
+++ b/src/simulat/core/surfaces/game_map/game_map.py
@@ -121,6 +121,9 @@ class GameMap(Surface):
             self.camera.rect
         )
 
+        # draw onto the game scene
+        self.scene.surface.blit(self.surface, (0, 0))
+
     @time_it
     def _init_tiles(self):
         """Initialize the map tiles."""

--- a/src/simulat/core/surfaces/game_map/sidebar.py
+++ b/src/simulat/core/surfaces/game_map/sidebar.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""Sidebar surface module."""
+
+from __future__ import annotations
+
+import logging as lg
+
+from src.simulat.core.surfaces.surface import Surface
+
+
+class Sidebar(Surface):
+    """Sidebar class.
+
+    The sidebar is a surface that is displayed on the right side of the game
+    scene. It contains information about the game, the player, etc.
+    """
+    def __init__(self, scene: Scene) -> None:
+        """Initialize the sidebar.
+
+        Args:
+            scene (Scene): The game scene.
+        """
+        self.logger = lg.getLogger(f"{__name__}.{type(self).__name__}")
+
+        self.logger.debug("Initializing sidebar surface...")
+
+        self.scene = scene
+
+        self.DISPLAY_SIZE = scene.size
+        self.SIDEBAR_SIZE = (256, self.DISPLAY_SIZE[1])
+        self.SIDEBAR_POS = (self.DISPLAY_SIZE[0] - self.SIDEBAR_SIZE[0], 0)
+
+        super().__init__(self.SIDEBAR_SIZE)
+
+        self.surface.fill((0, 0, 0))
+
+        self.add_text("Sidebar", ("center", "center"),
+                      (255, 255, 255), "topbar")
+
+        self.logger.debug(f"Sidebar size: {self.SIDEBAR_SIZE} px")
+
+    def update(self) -> None:
+        """Update the sidebar."""
+        pass
+
+    def render(self) -> None:
+        """Render the sidebar."""
+        self.scene.surface.blit(self.surface, self.SIDEBAR_POS)

--- a/src/simulat/core/surfaces/scenes/game_scene/game_scene.py
+++ b/src/simulat/core/surfaces/scenes/game_scene/game_scene.py
@@ -23,7 +23,7 @@ class GameScene(Scene):
         self.sidebar = Sidebar(self)
 
         # initialize map
-        self.game_map = GameMap()
+        self.game_map = GameMap(self)
 
     def update(self, delta: float) -> None:
         """Update the game scene.

--- a/src/simulat/core/surfaces/scenes/game_scene/game_scene.py
+++ b/src/simulat/core/surfaces/scenes/game_scene/game_scene.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from src.simulat.core.surfaces.scenes.scene import Scene
-
 from src.simulat.core.surfaces.game_map.game_map import GameMap
+from src.simulat.core.surfaces.game_map.sidebar import Sidebar
+from src.simulat.core.surfaces.scenes.scene import Scene
 
 
 class GameScene(Scene):
@@ -18,6 +18,9 @@ class GameScene(Scene):
     def __init__(self) -> None:
         """Initialize the game scene."""
         super().__init__()
+
+        # initialize sidebar
+        self.sidebar = Sidebar(self)
 
         # initialize map
         self.game_map = GameMap()
@@ -36,4 +39,5 @@ class GameScene(Scene):
             (0, 0),
         )
         self.game_map.render()
+        self.sidebar.render()
         self.draw(dest)


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [x] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Adds a sidebar to the Game Scene.
- Adds `display_size` attribute to GameMap which is the size of the game map's surface on the physical screen (`simulat.screen`).
- Changes the size of Camera's rect to the `GameMap.display_size`.
- Adds a blit of `GameMap.surface` onto the Game Scene's in `GameMap.render()`.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

![A screenshot of the game window with a sidebar on the right.](https://github.com/pufereq/simulat/assets/94570596/c8e9c048-5cec-409a-a70c-6f21390c34e4)

