### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/src/simulat/core/surfaces/game_map/sidebar.py
+++ b/src/simulat/core/surfaces/game_map/sidebar.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging as lg
 
 from src.simulat.core.surfaces.surface import Surface
+from src.simulat.data.colors import SimulatPalette
 
 
 class Sidebar(Surface):
@@ -32,10 +33,9 @@ class Sidebar(Surface):
 
         super().__init__(self.SIDEBAR_SIZE)
 
-        self.surface.fill((0, 0, 0))
+        self.surface.fill(SimulatPalette.BACKGROUND)
 
-        self.add_text("Sidebar", ("center", "center"),
-                      (255, 255, 255), "topbar")
+        self.add_text("Sidebar", ("center", "center"), font="topbar")
 
         self.logger.debug(f"Sidebar size: {self.SIDEBAR_SIZE} px")
 

--- a/src/simulat/core/surfaces/scenes/game_scene/game_scene.py
+++ b/src/simulat/core/surfaces/scenes/game_scene/game_scene.py
@@ -37,7 +37,7 @@ class GameScene(Scene):
             self.corner_overlay.surface,
             BasicPalette.MAGENTA,
             (0, 0, *self.game_map.display_size),
-            border_radius=8,
+            border_top_right_radius=8,
         )
 
     def update(self, delta: float) -> None:

--- a/src/simulat/core/surfaces/scenes/game_scene/game_scene.py
+++ b/src/simulat/core/surfaces/scenes/game_scene/game_scene.py
@@ -9,6 +9,7 @@ from src.simulat.core.surfaces.game_map.game_map import GameMap
 from src.simulat.core.surfaces.game_map.sidebar import Sidebar
 from src.simulat.core.surfaces.scenes.scene import Scene
 from src.simulat.core.surfaces.surface import Surface
+from src.simulat.data.colors import BasicPalette, SimulatPalette
 
 
 class GameScene(Scene):
@@ -30,10 +31,11 @@ class GameScene(Scene):
 
         # initialize corner overlay (rounded corners)
         self.corner_overlay = Surface(self.game_map.display_size)
-        self.corner_overlay.surface.set_colorkey((255, 0, 255))
+        self.corner_overlay.surface.set_colorkey(BasicPalette.MAGENTA)
+        self.corner_overlay.surface.fill(SimulatPalette.BACKGROUND)
         pg.draw.rect(
             self.corner_overlay.surface,
-            (255, 0, 255),
+            BasicPalette.MAGENTA,
             (0, 0, *self.game_map.display_size),
             border_radius=8,
         )

--- a/src/simulat/core/surfaces/scenes/scene.py
+++ b/src/simulat/core/surfaces/scenes/scene.py
@@ -40,7 +40,7 @@ class Scene:
             self.surface.add_text(
                 "FALLBACK SCENE",
                 (20, 20),
-                (255, 0, 0)
+                color="#ff0000"
             )
 
     def update(self, delta: float) -> None:

--- a/src/simulat/core/surfaces/surface.py
+++ b/src/simulat/core/surfaces/surface.py
@@ -55,7 +55,8 @@ class Surface:
         """
         return SubSurface(self, pos, size)
 
-    def fill(self, color: tuple[int, int, int]):
+    def fill(self, color: tuple[int, int, int] |
+             tuple[int, int, int, int] | str) -> pg.Rect:
         """Fill the surface with a color.
 
         Args:

--- a/src/simulat/core/surfaces/surface.py
+++ b/src/simulat/core/surfaces/surface.py
@@ -7,6 +7,7 @@ import logging as lg
 
 import pygame as pg
 
+from src.simulat.data.colors import SimulatPalette
 from src.simulat.core.game import simulat
 
 
@@ -96,8 +97,9 @@ class Surface:
         """
         return self.surface.blit(source, dest, area, special_flags)
 
-    def add_text(self, text: str, pos: tuple[int | str, int | str],
-                 color: tuple[int, int, int],
+    def add_text(self, text: str, pos: tuple[int | str, int | str], *,
+                 color: tuple[int, int, int] | tuple[int, int, int, int]
+                 | str = SimulatPalette.FOREGROUND,
                  font: str = "main"):
         """Add text to the surface.
 
@@ -137,6 +139,31 @@ class Surface:
                     " number (int), 'top', 'center', 'bottom'"
                 )
             y_pos = pos[1]
+
+        if isinstance(color, str):
+            color_str: str = color.strip("#").lower()
+
+            if len(color_str) == 3:  # #RGB -> (RRR, GGG, BBB, 255)
+                color = (
+                    int(color_str[0], 16) * 17,  # R
+                    int(color_str[1], 16) * 17,  # G
+                    int(color_str[2], 16) * 17,  # B
+                    255  # A
+                )
+            elif len(color_str) == 6:  # #RRGGBB -> (RRR, GGG, BBB, 255)
+                color = (
+                    int(color_str[:2], 16),  # R
+                    int(color_str[2:4], 16),  # G
+                    int(color_str[4:6], 16),  # B
+                    255  # A
+                )
+            elif len(color_str) == 8:  # #RRGGBBAA -> (RRR, GGG, BBB, AAA)
+                color = (
+                    int(color_str[:2], 16),  # R
+                    int(color_str[2:4], 16),  # G
+                    int(color_str[4:6], 16),  # B
+                    int(color_str[6:8], 16)  # A
+                )
 
         text_surface = simulat.fonts[font].render(text, True, color)
 

--- a/src/simulat/core/surfaces/topbar.py
+++ b/src/simulat/core/surfaces/topbar.py
@@ -50,36 +50,36 @@ class Topbar(Surface):
             (round(self.width * 0.3), self.height)
         )
 
-        self.debug_surface.fill((255, 0, 0))
-        self.title_surface.fill((0, 255, 0))
-        self.details_surface.fill((0, 0, 255))
+        self.debug_surface.fill(self.debug_color[1])
+        self.title_surface.fill(self.title_color[1])
+        self.details_surface.fill(self.details_color[1])
 
     def update_debug(self, text: str):
         self.debug_text = text
 
-        self.debug_surface.fill((255, 0, 0))
+        self.debug_surface.fill(self.debug_color[1])
         self.debug_surface.add_text(
             self.debug_text, ("left", "center"),
-            (255, 255, 255),
-            "topbar"
+            color=self.debug_color[0],
+            font="topbar"
         )
 
     def update_title(self, text: str):
         self.title_text = text
 
-        self.title_surface.fill((0, 255, 0))
+        self.title_surface.fill(self.title_color[1])
         self.title_surface.add_text(
             self.title_text, ("center", "center"),
-            (255, 255, 255),
-            "topbar"
+            color=self.title_color[0],
+            font="topbar"
         )
 
     def update_details(self, text: str):
         self.details_text = text
 
-        self.details_surface.fill((0, 0, 255))
+        self.details_surface.fill(self.details_color[1])
         self.details_surface.add_text(
             self.details_text, ("right", "center"),
-            (255, 255, 255),
-            "topbar"
+            color=self.details_color[0],
+            font="topbar"
         )

--- a/src/simulat/core/surfaces/topbar.py
+++ b/src/simulat/core/surfaces/topbar.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging as lg
 
 from src.simulat.core.surfaces.surface import Surface
+from src.simulat.data.colors import SimulatPalette
 
 
 class Topbar(Surface):
@@ -16,12 +17,19 @@ class Topbar(Surface):
 
         super().__init__((simulat.SIZE[0], 24), (0, 0))
 
-        # init sub-surfaces
-        self._init_sub_surfaces()
-
         self.debug_text: str = ""
         self.title_text: str = ""
         self.details_text: str = ""
+
+        self.debug_color: list[str] = [SimulatPalette.FOREGROUND,
+                                       SimulatPalette.BACKGROUND]
+        self.title_color: list[str] = [SimulatPalette.FOREGROUND,
+                                       SimulatPalette.BACKGROUND]
+        self.details_color: list[str] = [SimulatPalette.FOREGROUND,
+                                         SimulatPalette.BACKGROUND]
+
+        # init sub-surfaces
+        self._init_sub_surfaces()
 
         # add text
         self.update_debug("simulat")

--- a/src/simulat/data/colors.py
+++ b/src/simulat/data/colors.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Color definitions."""
+
+from typing import Final
+
+
+class BasicPalette:
+    """A class containing basic color definitions."""
+    BLACK: Final[str] = "#000000"
+    WHITE: Final[str] = "#ffffff"
+    RED: Final[str] = "#ff0000"
+    GREEN: Final[str] = "#00ff00"
+    BLUE: Final[str] = "#0000ff"
+    YELLOW: Final[str] = "#ffff00"
+    CYAN: Final[str] = "#00ffff"
+    MAGENTA: Final[str] = "#ff00ff"
+    ORANGE: Final[str] = "#ff7f00"
+    PURPLE: Final[str] = "#7f00ff"
+    PINK: Final[str] = "#ff007f"
+    BROWN: Final[str] = "#7f3f00"
+    GREY: Final[str] = "#808080"
+    LIGHT_GREY: Final[str] = "#d3d3d3"
+    DARK_GREY: Final[str] = "#a9a9a9"
+
+
+class SimulatPalette:
+    """A class containing the simulat color palette."""
+    BACKGROUND: Final[str] = "#364652"
+    FOREGROUND: Final[str] = "#EDF2EF"
+    ACCENT: Final[str] = "#9D8DF1"
+    ACCENT1: Final[str] = "#9CB7C7"
+    HIGHLIGHT: Final[str] = "#9AE19D"
+    SHADOW: Final[str] = "#251A18"


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [x] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- #32
  - Adds two color palettes: Basic and Simulat. The basic palette contains the basic colors, the simulat palette contains simulat's GUI Colors.
  - Adds support for hex color codes to `Surface.fill()` and `Surface.add_text()` methods.
  - Changes the rounded corners around the game map to only be on the top right corner.

## Related Tickets

- related issue #32 
- closes #

## Instructions, Screenshots

![A screenshot of 0.9.0's GUI changes.](https://github.com/pufereq/simulat/assets/94570596/ffaf1ec2-0e3a-4c57-b5a7-4909c3273456)
