### PR TITLE
feat: add button containers

### DIFF
--- a/src/simulat/core/surfaces/buttons/button.py
+++ b/src/simulat/core/surfaces/buttons/button.py
@@ -35,10 +35,12 @@ class Button(Surface):
                 "main".
         """
         super().__init__(size, pos)
-        self.rect = self.surface.get_rect(topleft=pos)
+        self.pos = pos
+        self.rect = pg.Rect(self.pos, size)
 
-        self.logger.debug(f"Creating button: '{text}' at {pos} with size {size}, "
-                          f"enabled: {enabled}, action: {on_click}")
+        self.logger.debug(f"Creating button: '{text}' at {pos}"
+                          f" size: {size}, enabled: {enabled},"
+                          f" action: {on_click}")
 
         self.enabled = enabled
         self.text = text

--- a/src/simulat/core/surfaces/buttons/button_container.py
+++ b/src/simulat/core/surfaces/buttons/button_container.py
@@ -16,6 +16,17 @@ class ButtonContainer:
 
     A button container is a container for buttons. It is used to group buttons
     together and handle their input and rendering.
+
+    Usage:
+    ```python
+    button_container = ButtonContainer(
+        parent_surface,
+        [
+            Button("Button 1", (100, 100), (100, 50)),
+            Button("Button 2", (100, 200), (100, 50))
+        ]
+    )
+    ```
     """
     def __init__(self, parent: Surface, buttons: list[Button]):
         """Initialize the button container."""

--- a/src/simulat/core/surfaces/buttons/button_container.py
+++ b/src/simulat/core/surfaces/buttons/button_container.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""TODO"""
+
+from __future__ import annotations
+
+import logging as lg
+
+import pygame as pg
+
+from src.simulat.core.surfaces.buttons.button import Button
+from src.simulat.core.surfaces.surface import Surface
+
+
+class ButtonContainer:
+    """Button container class.
+
+    A button container is a container for buttons. It is used to group buttons
+    together and handle their input and rendering.
+    """
+    def __init__(self, parent: Surface, buttons: list[Button]):
+        """Initialize the button container."""
+        self.logger = lg.getLogger(f"{__name__}.{type(self).__name__}")
+        self.logger.info("Initializing button container...")
+
+        self.parent = parent
+        self.buttons = buttons
+
+    def __iter__(self):
+        return iter(self.buttons)
+
+    def __getitem__(self, index: int) -> Button:
+        return self.buttons[index]
+
+    def __len__(self) -> int:
+        return len(self.buttons)
+
+    def input(self, *, events: list[pg.event.Event], keys: dict[int, bool],
+              mouse_pos: tuple[int, int],
+              mouse_buttons: tuple[bool, bool, bool]) -> None:
+        """Handle input events.
+
+        Args:
+            events (list[pg.event.Event]): List of pygame events.
+            keys (dict[int, bool]): Dictionary of pressed keys.
+            mouse_pos (tuple[int, int]): Position of the mouse.
+            mouse_buttons (tuple[bool, bool, bool]): State of the mouse buttons.
+        """
+
+        mouse_pos = (
+            mouse_pos[0] - self.parent.pos_x,
+            mouse_pos[1] - self.parent.pos_y
+        )
+
+        for button in self.buttons:
+            button.input(events=events, keys=keys, mouse_pos=mouse_pos,
+                         mouse_buttons=mouse_buttons)
+
+    def render(self) -> None:
+        """Render the button container."""
+        for button in self.buttons:
+            button.render(self.parent)

--- a/src/simulat/core/surfaces/game_map/sidebar.py
+++ b/src/simulat/core/surfaces/game_map/sidebar.py
@@ -27,11 +27,13 @@ class Sidebar(Surface):
 
         self.scene = scene
 
-        self.DISPLAY_SIZE = scene.size
-        self.SIDEBAR_SIZE = (256, self.DISPLAY_SIZE[1])
-        self.SIDEBAR_POS = (self.DISPLAY_SIZE[0] - self.SIDEBAR_SIZE[0], 0)
+        self.PARENT_POS = scene.pos
+        self.PARENT_SIZE = scene.size
+        self.SIDEBAR_SIZE = (256, self.PARENT_SIZE[1])
+        self.ABSOLUTE_SIDEBAR_POS = (self.PARENT_SIZE[0] - self.SIDEBAR_SIZE[0], 24)
+        self.RELATIVE_SIDEBAR_POS = (self.ABSOLUTE_SIDEBAR_POS[0], 0)
 
-        super().__init__(self.SIDEBAR_SIZE)
+        super().__init__(self.SIDEBAR_SIZE, self.ABSOLUTE_SIDEBAR_POS)
 
         self.surface.fill(SimulatPalette.BACKGROUND)
 
@@ -45,4 +47,4 @@ class Sidebar(Surface):
 
     def render(self) -> None:
         """Render the sidebar."""
-        self.scene.surface.blit(self.surface, self.SIDEBAR_POS)
+        self.scene.surface.blit(self.surface, self.RELATIVE_SIDEBAR_POS)

--- a/src/simulat/core/surfaces/scenes/main_menu_scene/main_menu_scene.py
+++ b/src/simulat/core/surfaces/scenes/main_menu_scene/main_menu_scene.py
@@ -9,6 +9,7 @@ import pygame as pg
 
 from src.simulat.core.game import simulat
 from src.simulat.core.surfaces.buttons.button import Button
+from src.simulat.core.surfaces.buttons.button_container import ButtonContainer
 from src.simulat.core.surfaces.scenes.scene import Scene
 from src.simulat.core.time_it import Timer
 from src.simulat.data.colors import BasicPalette, SimulatPalette
@@ -37,19 +38,15 @@ class MainMenuScene(Scene):
         self.load_thread = th.Thread(name="Loading thread",
                                      target=self._load_game, daemon=True)
 
-        self.buttons: list[Button] = [
-            Button("New Game", (386, 400), (512, 48),
-                   on_click=self._start_load_thread),
-
-            Button("Load Game", (386, 464), (512, 48),
-                   on_click=None, enabled=False),
-
-            Button("Settings", (386, 528), (248, 48),
-                   on_click=None, enabled=False),
-
-            Button("Exit", (650, 528), (248, 48),
-                   on_click=simulat.quit)
-        ]
+        self.button_container = ButtonContainer(
+            self.surface,
+            [
+                Button("New Game", (386, 400), (512, 48), on_click=self._start_load_thread),
+                Button("Load Game", (386, 464), (512, 48), on_click=None, enabled=False),
+                Button("Settings", (386, 528), (248, 48), on_click=None, enabled=False),
+                Button("Exit", (650, 528), (248, 48), on_click=simulat.quit)
+            ]
+        )
 
         self.surface.surface.fill(SimulatPalette.BACKGROUND)
 
@@ -68,7 +65,7 @@ class MainMenuScene(Scene):
 
     def _start_load_thread(self):
         if not self.load_thread.is_alive():
-            self.buttons[0].enabled = False  # prevent multiple clicks
+            self.button_container[0].enabled = False  # prevent multiple clicks
             self.load_thread.start()
 
     def input(self, *, events: list[pg.event.Event], keys: dict[int, bool],
@@ -81,14 +78,10 @@ class MainMenuScene(Scene):
             keys (dict[int, bool]): Dictionary of pressed keys.
         """
 
-        # align mouse position with the surface position
-        mouse_pos = (mouse_pos[0] - self.surface.pos_x,
-                     mouse_pos[1] - self.surface.pos_y)
-
         # handle input for buttons
-        for button in self.buttons:
-            button.input(events=events, keys=keys, mouse_pos=mouse_pos,
-                         mouse_buttons=mouse_buttons)
+        self.button_container.input(events=events, keys=keys,
+                                    mouse_pos=mouse_pos,
+                                    mouse_buttons=mouse_buttons)
 
         # load the game map if the user presses enter, temporary before
         # main menu is implemented
@@ -109,8 +102,7 @@ class MainMenuScene(Scene):
         self.surface.surface.blit(self.logo, (240, 200))
 
         # draw buttons
-        for button in self.buttons:
-            button.render(self.surface)
+        self.button_container.render()
 
         if self.load_thread.is_alive():
             self.surface.fill(SimulatPalette.BACKGROUND)

--- a/src/simulat/core/surfaces/scenes/scene.py
+++ b/src/simulat/core/surfaces/scenes/scene.py
@@ -26,9 +26,11 @@ class Scene:
 
         self.logger.debug(f"Initializing scene {self.id}...")
         self.size = (simulat.SIZE[0], simulat.SIZE[1] - simulat.topbar.height)
+        self.pos = (0, simulat.topbar.height)
+
         self.surface = Surface(
             self.size,
-            (0, simulat.topbar.height)
+            self.pos
         )
 
         self.surface.fill((255, 255, 255))


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [x] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [x] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Adds a `pos` attribute to `Scene` class.
- Changes atribute naming in `Sidebar` class.
- Adds `Button.pos` attribute.
- Makes `Button.rect` an independent rect instead of inheriting surface's.
- Adds a button container class `ButtonContainer` to group buttons.
- Makes use of button containers in main menu scene.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

### Usage:

#### Initialization:

```python
button_container = ButtonContainer(
    parent_surface,
    [
        Button("Button 1", (100, 100), (100, 50)),
        Button("Button 2", (100, 200), (100, 50))
    ]
)
```

#### Input handling:

```python
button_container.input(
    events=events,
    keys=keys,
    mouse_pos=mouse_pos,
    mouse_buttons=mouse_buttons
)
```

#### Rendering:

```python
button_container.render()
```

Changes invisible to user.
