### PR TITLE
feat(camera.py): cap camera position within player's distance

### DIFF
--- a/src/simulat/core/characters/camera.py
+++ b/src/simulat/core/characters/camera.py
@@ -10,4 +10,30 @@ class Camera(Character):
     def __init__(self, game_map: GameMap, pos: tuple[float, float]) -> None:
         super().__init__(game_map, pos, game_map.display_size, "px",
                          can_collide=False)
+        self.max_distance_from_player: float = 8  # tiles
+
         self.logger.debug(f"Camera size: {self.px_size} px")
+
+    def _cap_position(self, pos_tiles: tuple[float, float]) -> None:
+        """
+        Cap the camera position to within the distance to player. Then call
+        the parent method to cap the position to within the map size.
+        """
+        player_pos = self.game_map.player.pos
+        pos_tiles = list(pos_tiles)
+
+        # cap x
+        if abs(player_pos[0] - pos_tiles[0]) > self.max_distance_from_player:
+            if player_pos[0] > pos_tiles[0]:
+                pos_tiles[0] = player_pos[0] - self.max_distance_from_player
+            else:
+                pos_tiles[0] = player_pos[0] + self.max_distance_from_player
+
+        # cap y
+        if abs(player_pos[1] - pos_tiles[1]) > self.max_distance_from_player:
+            if player_pos[1] > pos_tiles[1]:
+                pos_tiles[1] = player_pos[1] - self.max_distance_from_player
+            else:
+                pos_tiles[1] = player_pos[1] + self.max_distance_from_player
+
+        return super()._cap_position(pos_tiles)


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [ ] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Caps the camera's position to a certain distance (8 tiles) from the player.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

The max distance from player is set to 8 tiles.
![Max camera distance capping.](https://github.com/pufereq/simulat/assets/94570596/6a88ba2a-2125-437b-82b8-46a610a5c37a)
