### PR TITLE
feat: reduce internal resolution and scale

### DIFF
--- a/src/simulat/core/game.py
+++ b/src/simulat/core/game.py
@@ -177,6 +177,10 @@ class Simulat:
             pg.display.set_caption(f"simulat {VERSION} - FPS: {self.clock.get_fps():.2f}")
 
             # update screen
+            self.display.blit(
+                pg.transform.scale(self.internal_screen, self.DISPLAY_SIZE),
+                (0, 0)
+            )
             pg.display.flip()
 
             # limit framerate

--- a/src/simulat/core/game.py
+++ b/src/simulat/core/game.py
@@ -9,7 +9,7 @@ from typing import Final
 
 import pygame as pg
 
-from src.simulat.core import log_exception
+from src.simulat.core.log_exception import log_exception
 
 # set up logging
 lg.basicConfig(format="%(asctime)s : %(levelname)-8s : %(threadName)s : %(filename)s:"
@@ -153,7 +153,7 @@ class Simulat:
                 if event.type == pg.QUIT:
                     self.running = False
 
-            self.screen.fill((30, 30, 30))
+            self.internal_screen.fill((30, 30, 30))
 
             if keys[pg.K_ESCAPE]:
                 self.running = False
@@ -169,10 +169,10 @@ class Simulat:
 
             # RENDER
             # draw scene
-            self.scenes[self.active_scene].render(self.screen)
+            self.scenes[self.active_scene].render(self.internal_screen)
 
             # draw topbar
-            self.screen.blit(self.topbar.surface, (0, 0))
+            self.internal_screen.blit(self.topbar.surface, (0, 0))
 
             pg.display.set_caption(f"simulat {VERSION} - FPS: {self.clock.get_fps():.2f}")
 

--- a/src/simulat/core/game.py
+++ b/src/simulat/core/game.py
@@ -54,9 +54,9 @@ class Simulat:
         # initialize fonts
         pg.font.init()
         self.fonts: dict[str, pg.font.Font] = {
-            "main": pg.font.SysFont("monospace", 16),
-            "topbar": pg.font.SysFont("monospace", 22),
-            "button": pg.font.SysFont("monospace", 20),
+            "main": pg.font.SysFont("monospace", 8),
+            "topbar": pg.font.SysFont("monospace", 11),
+            "button": pg.font.SysFont("monospace", 10),
         }
 
         # initialize focused surfaces

--- a/src/simulat/core/game.py
+++ b/src/simulat/core/game.py
@@ -25,7 +25,8 @@ class Simulat:
         """Initialize pygame and the main window."""
         # constants
         self.FPS: Final = 60
-        self.SIZE: Final = (1280, 720)
+        self.INTERNAL_SCREEN_SIZE: Final = (640, 360)
+        self.DISPLAY_SIZE = (1280, 720)
 
         # set up logging
         self.logger = lg.getLogger(f"{__name__}.{type(self).__name__}")

--- a/src/simulat/core/game.py
+++ b/src/simulat/core/game.py
@@ -43,7 +43,8 @@ class Simulat:
         pg.display.set_caption(f"simulat {VERSION}")
 
         # initialize screen
-        self.screen = pg.display.set_mode(self.SIZE)
+        self.internal_screen = pg.Surface(self.INTERNAL_SCREEN_SIZE)
+        self.display = pg.display.set_mode(self.DISPLAY_SIZE)
 
         # initialize clock
         self.clock = pg.time.Clock()

--- a/src/simulat/core/surfaces/buttons/button.py
+++ b/src/simulat/core/surfaces/buttons/button.py
@@ -74,7 +74,7 @@ class Button(Surface):
             self.rounded_corner_overlay.surface,
             BasicPalette.MAGENTA,
             (0, 0, *size),
-            border_radius=8
+            border_radius=4
         )
 
     def __repr__(self) -> str:

--- a/src/simulat/core/surfaces/buttons/button_container.py
+++ b/src/simulat/core/surfaces/buttons/button_container.py
@@ -10,6 +10,8 @@ import pygame as pg
 from src.simulat.core.surfaces.buttons.button import Button
 from src.simulat.core.surfaces.surface import Surface
 
+from src.simulat.core.game import simulat
+
 
 class ButtonContainer:
     """Button container class.
@@ -73,8 +75,8 @@ class ButtonContainer:
         """
 
         mouse_pos = (
-            mouse_pos[0] - self.parent.pos_x,
-            mouse_pos[1] - self.parent.pos_y
+            (mouse_pos[0] / (simulat.DISPLAY_SIZE[0] / simulat.INTERNAL_SCREEN_SIZE[0])) - self.parent.pos_x,
+            (mouse_pos[1] / (simulat.DISPLAY_SIZE[1] / simulat.INTERNAL_SCREEN_SIZE[1])) - self.parent.pos_y
         )
 
         for button in self.buttons:

--- a/src/simulat/core/surfaces/game_map/sidebar.py
+++ b/src/simulat/core/surfaces/game_map/sidebar.py
@@ -29,7 +29,7 @@ class Sidebar(Surface):
 
         self.PARENT_POS = scene.pos
         self.PARENT_SIZE = scene.size
-        self.SIDEBAR_SIZE = (256, self.PARENT_SIZE[1])
+        self.SIDEBAR_SIZE = (128, self.PARENT_SIZE[1])
         self.ABSOLUTE_SIDEBAR_POS = (self.PARENT_SIZE[0] - self.SIDEBAR_SIZE[0], 24)
         self.RELATIVE_SIDEBAR_POS = (self.ABSOLUTE_SIDEBAR_POS[0], 0)
 

--- a/src/simulat/core/surfaces/game_map/tiles/tile.py
+++ b/src/simulat/core/surfaces/game_map/tiles/tile.py
@@ -9,7 +9,7 @@ from typing import Final
 from src.simulat.core.surfaces.surface import Surface
 
 
-TILE_SIZE: Final = 64  # pixels
+TILE_SIZE: Final = 32  # pixels
 
 
 class Tile():

--- a/src/simulat/core/surfaces/scenes/main_menu_scene/main_menu_scene.py
+++ b/src/simulat/core/surfaces/scenes/main_menu_scene/main_menu_scene.py
@@ -53,6 +53,7 @@ class MainMenuScene(Scene):
         # add logo
         logo_path = "assets/logo/ingame/logo_menu.png"
         self.logo = pg.image.load(logo_path).convert_alpha()
+        self.logo = pg.transform.scale(self.logo, (412, 82))
 
     def _load_game(self):
         from src.simulat.core.surfaces.scenes.game_scene.game_scene import \
@@ -99,7 +100,7 @@ class MainMenuScene(Scene):
         simulat.topbar.update_title("main menu")
 
         # draw logo
-        self.surface.surface.blit(self.logo, (240, 200))
+        self.surface.surface.blit(self.logo, (120, 100))
 
         # draw buttons
         self.button_container.render()

--- a/src/simulat/core/surfaces/scenes/main_menu_scene/main_menu_scene.py
+++ b/src/simulat/core/surfaces/scenes/main_menu_scene/main_menu_scene.py
@@ -41,10 +41,10 @@ class MainMenuScene(Scene):
         self.button_container = ButtonContainer(
             self.surface,
             [
-                Button("New Game", (386, 400), (512, 48), on_click=self._start_load_thread),
-                Button("Load Game", (386, 464), (512, 48), on_click=None, enabled=False),
-                Button("Settings", (386, 528), (248, 48), on_click=None, enabled=False),
-                Button("Exit", (650, 528), (248, 48), on_click=simulat.quit)
+                Button("New Game", (193, 200), (256, 24), on_click=self._start_load_thread),
+                Button("Load Game", (193, 230), (256, 24), on_click=None, enabled=False),
+                Button("Settings", (193, 260), (124, 24), on_click=None, enabled=False),
+                Button("Exit", (325, 260), (124, 24), on_click=simulat.quit)
             ]
         )
 

--- a/src/simulat/core/surfaces/scenes/scene.py
+++ b/src/simulat/core/surfaces/scenes/scene.py
@@ -25,7 +25,8 @@ class Scene:
         self.logger = lg.getLogger(f"{__name__}.{self.id}")
 
         self.logger.debug(f"Initializing scene {self.id}...")
-        self.size = (simulat.SIZE[0], simulat.SIZE[1] - simulat.topbar.height)
+        self.size = (simulat.INTERNAL_SCREEN_SIZE[0],
+                     simulat.INTERNAL_SCREEN_SIZE[1] - simulat.topbar.height)
         self.pos = (0, simulat.topbar.height)
 
         self.surface = Surface(

--- a/src/simulat/core/surfaces/topbar.py
+++ b/src/simulat/core/surfaces/topbar.py
@@ -15,7 +15,7 @@ class Topbar(Surface):
         self.logger = lg.getLogger(f"{__name__}.{type(self).__name__}")
         self.logger.debug("Initializing topbar...")
 
-        super().__init__((simulat.SIZE[0], 24), (0, 0))
+        super().__init__((simulat.INTERNAL_SCREEN_SIZE[0], 12), (0, 0))
 
         self.debug_text: str = ""
         self.title_text: str = ""


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [x] `  chore   ` :ticket: chores
- [x] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Decreases the resolution of the game to `640x360` (2x smaller).
- Decreases tile size to 32px.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

Peformance improvements:

| Revision                            | Main Menu  | Game Map   |
|-------------------------------------|------------|------------|
| Before (1280x720 native)            | 498.26 FPS | 296.80 FPS |
| After (640x360, scaled to 1280x720) | 572.10 FPS | 430.14 FPS |
| Performance improvement             | +14.92%    | +44.92%    |

Graphical comparison:

Scaled:
![scaling_640x360_new](https://github.com/pufereq/simulat/assets/94570596/13aeba89-0384-4fc2-955d-d3dcc0243257)

Native:
![scaling_old_0.13.0](https://github.com/pufereq/simulat/assets/94570596/3db21429-dbf0-480f-b544-fb81c06cdf7f)
