### PR TITLE
feat(#73): add debug screen

### DIFF
--- a/src/simulat/core/game.py
+++ b/src/simulat/core/game.py
@@ -49,8 +49,10 @@ class Simulat:
         self.logger.debug("Initializing pygame...")
         from src.simulat.core.version import VERSION
 
+        self.version = VERSION
+
         pg.init()
-        pg.display.set_caption(f"simulat {VERSION}")
+        pg.display.set_caption(f"simulat {self.version}")
 
         # initialize screen
         self.internal_screen = pg.Surface(self.INTERNAL_SCREEN_SIZE)

--- a/src/simulat/core/scenes/game_scene/game_map/debug_screen.py
+++ b/src/simulat/core/scenes/game_scene/game_map/debug_screen.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""Debug screen module for GameMap.
+
+This module contains the debug screen, which is responsible for displaying information about the game.
+"""
+
+from __future__ import annotations
+
+import logging as lg
+import platform
+from typing import Any
+
+import pygame as pg
+
+from src.simulat.core.colors import BasicPalette, SimulatPalette
+from src.simulat.core.game import simulat
+from src.simulat.core.scenes.game_scene.game_map.game_map import GameMap
+from src.simulat.core.surfaces.surface import Surface
+
+
+class DebugScreen:
+    """Debug screen class.
+
+    The debug screen is responsible for displaying information about the game.
+    """
+
+    def __init__(self, game_map: GameMap) -> None:
+        """Initialize the debug screen.
+
+        Args:
+            game_map (GameMap): The game map.
+        """
+        self.logger = lg.getLogger(f"{__name__}.{type(self).__name__}")
+        self.logger.info("Initializing debug screen...")
+
+        self.game_map: GameMap = game_map
+
+        self.surface: Surface = Surface(self.game_map.viewport_size)
+        # self.surface.surface.set_alpha(128)
+        self.surface.surface.set_colorkey(BasicPalette.MAGENTA)
+        self.visible: bool = False
+        self.tiles_loaded: int = 0
+
+    def render(self) -> None:
+        """Render the debug screen."""
+
+        world_data: list[str] = ["No world loaded"]
+        tile_data: list[str] = ["Out of bounds"]
+
+        # data requiring the world to be loaded
+        if self.game_map.world is not None:
+            # if None, the player is out of bounds
+            if self.game_map.world.player.current_tile is not None:
+                tile_data = [
+                    f"Tile position: {self.game_map.world.player.current_tile.pos}",
+                    f"Tile type: {self.game_map.world.player.current_tile.tile_type.id}",
+                ]
+
+            # set world data
+            world_data = [
+                f"World: {self.game_map.world.id}",
+                f"Tiles: {self.tiles_loaded}/{len(self.game_map.world.chunk_map) * self.game_map.world.CHUNK_SIZE ** 2}",
+                f"Chunks: {len(self.game_map.world.chunk_map)}",
+                "",
+                f"XY: {self.game_map.world.player.pos[0]:.4f} / {self.game_map.world.player.pos[1]:.4f}",
+                f"Chunk: {self.game_map.world.player.current_chunk[0]} {self.game_map.world.player.current_chunk[1]} at {self.game_map.world.player.pos_in_chunk[0]} {self.game_map.world.player.pos_in_chunk[1]}",
+                *tile_data,
+            ]
+
+        # structure of the debug screen
+        self.structure: dict[str, list[str]] = {
+            "left": [
+                f"simulat {simulat.version}",
+                f"{simulat.clock.get_fps():.0f} fps, {simulat.clock.get_time()} ms",
+                "",
+                *world_data,  # display world data
+            ],
+            "center": [],
+            "right": [
+                f"Python {platform.python_version()}",
+                f"Pygame {pg.version.ver}, SDL {pg.version.SDL}",
+                f"Display: {simulat.DISPLAY_SIZE[0]}x{simulat.DISPLAY_SIZE[1]} (internal: {simulat.INTERNAL_SCREEN_SIZE[0]}x{simulat.INTERNAL_SCREEN_SIZE[1]})",
+                "",
+                f"{platform.platform()}",
+            ],
+        }
+
+        # fill the surface with the background color
+        self.surface.fill(BasicPalette.MAGENTA)
+
+        # render the structure
+        for side, content in self.structure.items():
+            for i, line in enumerate(content):
+                self.surface.blit_text(
+                    line,
+                    (side, 12 * i),
+                    color=SimulatPalette.FOREGROUND,
+                    antialias=False,
+                )
+
+        self.game_map.surface.blit(self.surface.surface, (0, 0))

--- a/src/simulat/core/scenes/game_scene/game_map/game_map.py
+++ b/src/simulat/core/scenes/game_scene/game_map/game_map.py
@@ -96,10 +96,11 @@ class GameMap:
         if self.world is not None:
             self.world.player.update(delta)
             # self.camera.update(delta)
-            try:
-                standing_on_tile_name = self.world.player.current_tile.tile_type.label
-            except KeyError:
-                standing_on_tile_name = "Void"
+            current_tile = self.world.player.current_tile
+            if current_tile is not None:
+                standing_on_tile_name = current_tile.tile_type.label
+            else:
+                standing_on_tile_name = "Out of bounds"
             simulat.topbar.update_title(
                 f"XY: {self.world.player.pos[0]:.3f}, {self.world.player.pos[1]:.3f} on "
                 f"{standing_on_tile_name}"

--- a/src/simulat/core/scenes/game_scene/game_map/game_map.py
+++ b/src/simulat/core/scenes/game_scene/game_map/game_map.py
@@ -51,6 +51,10 @@ class GameMap:
 
         self.world: World | None = None
 
+        from src.simulat.core.scenes.game_scene.game_map.debug_screen import DebugScreen
+
+        self.debug_screen: DebugScreen = DebugScreen(self)
+
         self.surface = Surface(self.viewport_size)
 
         # NOTE: debug
@@ -86,6 +90,12 @@ class GameMap:
                 self.world.player.velocity[0] += -1
             if keys[pg.K_d]:
                 self.world.player.velocity[0] += 1
+
+        # debug screen toggle
+        for event in events:
+            if event.type == pg.KEYDOWN:
+                if event.key == pg.K_F9:
+                    self.debug_screen.visible = not self.debug_screen.visible
 
     def update(self, delta: float) -> None:
         """Update the game map.
@@ -131,6 +141,7 @@ class GameMap:
             )
 
             # render the chunks
+            self.debug_screen.tiles_loaded = 0
             for y in range(y_chunks):
                 for x in range(x_chunks):
                     # calculate the target chunk
@@ -146,6 +157,7 @@ class GameMap:
 
                     # render the tiles in the target chunk
                     for tile in self.world.chunk_map[target_chunk].values():
+                        self.debug_screen.tiles_loaded += 1
                         tile.draw(
                             self.surface,
                             (
@@ -160,5 +172,9 @@ class GameMap:
 
             # render the player
             self.world.player.render(self.surface)
+
+        # render the debug screen
+        if self.debug_screen.visible:
+            self.debug_screen.render()
 
         self.game_scene.surface.blit(self.surface.surface, (0, 0))


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [x] `  chore   ` :ticket: chores
- [x] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Adds a debug screen, displaying more detailed, debugging information about the game.
- Adds `Simulat.version` constant for easier access.

## Related Tickets

- related issue #73 
- closes #

## Instructions, Screenshots

Toggle the debug screen using the `F9` key.

![The debug screen in action.](https://github.com/pufereq/simulat/assets/94570596/421efbe5-e1c9-4c91-b183-74339c08b297)

A screenshot of the layout:

![A screenshot of the visible layout](https://github.com/pufereq/simulat/assets/94570596/8cd7e1d6-5599-4564-b209-a94f2cbdcb90)


