### PR TITLE
feat(#78): rewrite `Surface.blit_text()` method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pygame
+pygame-ce
 pyyaml
 cerberus

--- a/simulat/core/colors.py
+++ b/simulat/core/colors.py
@@ -4,6 +4,42 @@
 from typing import Final
 
 
+def hex_to_rgba(hex_color: str) -> tuple[int, int, int, int]:
+    """Convert a hex color to an RGBA tuple.
+
+    Args:
+        hex_color (str): Hex color string.
+
+    Returns:
+        tuple[int, int, int, int]: RGBA tuple.
+    """
+    hex_color = hex_color.lstrip("#").lower()
+    if len(hex_color) == 3:  # #RGB -> (RRR, GGG, BBB, 255)
+        rgba_value = (
+            int(hex_color[0], 16) * 17,  # R
+            int(hex_color[1], 16) * 17,  # G
+            int(hex_color[2], 16) * 17,  # B
+            255,  # A
+        )
+    elif len(hex_color) == 6:  # #RRGGBB -> (RRR, GGG, BBB, 255)
+        rgba_value = (
+            int(hex_color[:2], 16),  # R
+            int(hex_color[2:4], 16),  # G
+            int(hex_color[4:6], 16),  # B
+            255,  # A
+        )
+    elif len(hex_color) == 8:  # #RRGGBBAA -> (RRR, GGG, BBB, AAA)
+        rgba_value = (
+            int(hex_color[:2], 16),  # R
+            int(hex_color[2:4], 16),  # G
+            int(hex_color[4:6], 16),  # B
+            int(hex_color[6:8], 16),  # A
+        )
+    else:
+        raise ValueError(f"Invalid hex color: {hex_color}")
+    return rgba_value
+
+
 class BasicPalette:
     """A class containing basic color definitions."""
 

--- a/simulat/core/game.py
+++ b/simulat/core/game.py
@@ -8,7 +8,6 @@ import sys
 from typing import Final
 
 import pygame as pg
-import pygame.ftfont
 
 from simulat.core.config_handler import ConfigHandler
 from simulat.core.log_exception import log_exception
@@ -66,9 +65,9 @@ class Simulat:
         # initialize fonts
         pg.font.init()
         self.fonts: dict[str, pg.font.Font] = {
-            "main": pygame.ftfont.Font("assets/fonts/simulat.ttf", 12),
-            "topbar": pygame.ftfont.Font("assets/fonts/simulat.ttf", 12),
-            "button": pygame.ftfont.Font("assets/fonts/simulat.ttf", 12),
+            "main": pg.Font("assets/fonts/simulat.ttf", 12),
+            "topbar": pg.Font("assets/fonts/simulat.ttf", 12),
+            "button": pg.Font("assets/fonts/simulat.ttf", 12),
         }
 
         # initialize focused surfaces

--- a/simulat/core/scenes/game_scene/game_map/debug_screen.py
+++ b/simulat/core/scenes/game_scene/game_map/debug_screen.py
@@ -78,7 +78,7 @@ class DebugScreen:
             "center": [],
             "right": [
                 f"Python {platform.python_version()}",
-                f"Pygame {pg.version.ver}, SDL {pg.version.SDL}",
+                f"Pygame-ce {pg.version.ver}, SDL {pg.version.SDL}",
                 f"Display: {simulat.DISPLAY_SIZE[0]}x{simulat.DISPLAY_SIZE[1]} (internal: {simulat.INTERNAL_SCREEN_SIZE[0]}x{simulat.INTERNAL_SCREEN_SIZE[1]})",
                 "",
                 f"{platform.platform()}",
@@ -93,9 +93,8 @@ class DebugScreen:
             for i, line in enumerate(content):
                 self.surface.blit_text(
                     line,
-                    (side, 12 * i),
-                    color=SimulatPalette.FOREGROUND,
-                    antialias=False,
+                    (0, 12 * i),
+                    text_align=side,
                 )
 
         self.game_map.surface.blit(self.surface.surface, (0, 0))

--- a/simulat/core/scenes/game_scene/game_map/sidebar.py
+++ b/simulat/core/scenes/game_scene/game_map/sidebar.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging as lg
 
 from simulat.core.colors import SimulatPalette
+from simulat.core.scenes.scene import Scene
 from simulat.core.surfaces.surface import Surface
 
 
@@ -38,7 +39,13 @@ class Sidebar(Surface):
 
         self.surface.fill(SimulatPalette.BACKGROUND)
 
-        self.blit_text("Sidebar", ("center", "center"), font="topbar")
+        self.blit_text(
+            "Sidebar",
+            (0, 0),
+            text_align="center",
+            vertical_align="middle",
+            font="topbar",
+        )
 
         self.logger.debug(f"Sidebar size: {self.SIDEBAR_SIZE} px")
 

--- a/simulat/core/surfaces/buttons/button.py
+++ b/simulat/core/surfaces/buttons/button.py
@@ -139,7 +139,9 @@ class Button(Surface):
 
         self.blit_text(
             self.text,
-            ("center", "center"),
+            (0, 0),
+            text_align="center",
+            vertical_align="middle",
             color=self.color_scheme[self.state][1],
             font=self.font,
         )

--- a/simulat/core/surfaces/surface.py
+++ b/simulat/core/surfaces/surface.py
@@ -127,7 +127,7 @@ class Surface:
             tuple[int, int, int] | tuple[int, int, int, int] | str
         ) = SimulatPalette.FOREGROUND,
         font: str = "main",
-        antialias: bool = True,
+        antialias: bool = False,
     ):
         """Add text to the surface.
 
@@ -139,6 +139,8 @@ class Surface:
             color (tuple[int, int, int]): Color of the text. (R, G, B)
             font (str, optional): Name of the font to use.
                 Defaults to "main".
+            antialias (bool, optional): Whether to use font antialiasing.
+                Defaults to False.
         """
         if pos[0] == "left":
             x_pos = 0

--- a/simulat/core/surfaces/topbar.py
+++ b/simulat/core/surfaces/topbar.py
@@ -64,7 +64,9 @@ class Topbar(Surface):
         self.debug_surface.fill(self.debug_color[1])
         self.debug_surface.blit_text(
             self.debug_text,
-            ("left", "center"),
+            (0, 0),
+            text_align="left",
+            vertical_align="middle",
             color=self.debug_color[0],
             font="topbar",
         )
@@ -75,7 +77,9 @@ class Topbar(Surface):
         self.title_surface.fill(self.title_color[1])
         self.title_surface.blit_text(
             self.title_text,
-            ("center", "center"),
+            (0, 0),
+            text_align="center",
+            vertical_align="middle",
             color=self.title_color[0],
             font="topbar",
         )
@@ -86,7 +90,9 @@ class Topbar(Surface):
         self.details_surface.fill(self.details_color[1])
         self.details_surface.blit_text(
             self.details_text,
-            ("right", "center"),
+            (0, 0),
+            text_align="right",
+            vertical_align="middle",
             color=self.details_color[0],
             font="topbar",
         )


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [x] `  chore   ` :ticket: chores
- [x] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [x] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Migrates the game to `pygame-ce`.
- Changes fonts to use `pygame.Font` instead of `ftfont`.
- Default `antialiasing` argument to False in `Surface.blit_text()`.
- Adds a `hex_to_rgba()` function to convert hex color strings (`#RRGGBBAA`) to color tuples (`(RRR, GGG, BBB, AAA)`).
- Rewrites the `Surface.blit_text()` method.

## Related Tickets

- related issue #
- closes #78 

## Instructions, Screenshots
