### PR TITLE
feat(#77): add console

### DIFF
--- a/simulat/core/console.py
+++ b/simulat/core/console.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+"""Console module for simulat."""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+import pygame as pg
+
+from simulat.core.colors import SimulatPalette
+from simulat.core.game import simulat
+from simulat.core.object import Object
+from simulat.core.surfaces.surface import Surface
+
+
+class Console(Object):
+    """Console class.
+
+    A developer console for debugging and testing.
+
+    Usage:
+    - Toggle the console by pressing the backquote key (`).
+    - Type a command and press Enter to execute it.
+    - Prefix a command with `!` to evaluate it (e.g. `!2 + 2`).
+    """
+
+    def __init__(self) -> None:
+        """Initialize the console."""
+        super().__init__()
+        self.visible: bool = False
+        self.counter: int = 0
+
+        self.history: list[str] = []
+        self.history_index: int = 0
+
+        self.EVAL_GLOBALS: Final[dict[str, Any]] = {"simulat": simulat, "pg": pg}
+        self.COMMAND_MAP: Final[dict[str, Any]] = {
+            "help": "Available commands:\nexit, quit, toggle, help",
+            "exit": self.toggle,
+            "quit": self.toggle,
+            "toggle": self.toggle,
+        }
+
+        self.command: str = ""
+        self.result: str = ""
+        self._result_changed: bool = False
+        self.cursor: int = 0
+
+        self.colors: dict[str, str] = {
+            "border": SimulatPalette.ACCENT_PURPLE,
+            "command": SimulatPalette.ACCENT_BLUISH_DISABLED,
+            "result": SimulatPalette.BACKGROUND,
+        }
+
+        self.surface = Surface((simulat.INTERNAL_SCREEN_SIZE[0] - 100, 288), (50, 36))
+        self.surface.fill(self.colors["border"])
+        self.surface.surface.set_alpha(200)
+
+        self.command_surface = Surface((self.surface.width - 2, 12), (1, 1))
+        self.command_surface.fill(self.colors["command"])
+
+        # self.result_surface = self.surface.subsurface((1, 13), (self.surface.width - 2, self.surface.height - 14))
+        self.result_surface = Surface(
+            (self.surface.width - 2, self.surface.height - 14), (1, 13)
+        )
+        self.result_surface.fill(self.colors["result"])
+
+    def _execute(self, command: str) -> str:
+        """Execute a command.
+
+        Args:
+            command (str): The command to execute.
+
+        Returns:
+            str: The result of the command.
+        """
+        # command map lookup
+        if command in self.COMMAND_MAP:
+            self.logger.debug(
+                f"Command mapped ({command}): {repr(self.COMMAND_MAP[command])}"
+            )
+            if callable(self.COMMAND_MAP[command]):
+                result = self.COMMAND_MAP[command]()
+                return result if result is not None else "Command executed."
+            return self.COMMAND_MAP[command]
+
+        # if the command is not in the command map and doesn't start with `!`
+        # (indicating an eval/exec command), return an error
+        elif not command.startswith("!"):
+            return "Command not found."
+
+        # remove the `!` from the command
+        command = command.lstrip("!")
+
+        # eval/exec the command
+        try:
+            # eval
+            try:
+                result = str(eval(command, self.EVAL_GLOBALS))
+            except SyntaxError:
+                # exec
+                exec(command, self.EVAL_GLOBALS)
+                result = "Command executed."
+        except Exception as e:
+            result = f"An error occured:\n{str(e)}"
+            self.logger.warning(f"Command error: {str(e)}")
+        return result
+
+    def _render_result(self, result: Any) -> None:
+        """Render the result of the command.
+
+        Args:
+            result (Any): The result of the command.
+        """
+        self.result_surface.fill(self.colors["result"])
+        self.result_surface.blit_text(str(result), (0, 0))
+        self._result_changed = False
+
+    def toggle(self) -> None:
+        """Toggle the console."""
+        self.visible = not self.visible
+        if self.visible:
+            # set key repeat
+            pg.key.set_repeat(500, 50)
+            # display a warning message
+            self.result: str = (
+                "WARNING: This is a developer console.\nDO NOT paste code from untrusted sources."
+            )
+            self._result_changed: bool = True
+        else:
+            # reset key repeat
+            pg.key.set_repeat()
+        self.logger.debug(f"Console toggled, visible: {self.visible}")
+
+    def update(self) -> None:
+        """Update the console."""
+        if not self.visible:
+            return
+
+        self.counter += 1
+        if self.counter > 60:
+            self.counter = 0
+
+        for event in self._input["events"]:
+            if event.type == pg.KEYDOWN:
+                # remove the character before the cursor
+                if event.key == pg.K_BACKSPACE:
+                    self.command = self.command[:self.cursor - 1] + self.command[self.cursor:]  # fmt: skip
+                    self.cursor -= 1
+
+                # remove the character after the cursor
+                elif event.key == pg.K_DELETE:
+                    self.command = self.command[: self.cursor] + self.command[self.cursor + 1:]  # fmt: skip
+
+                # move the cursor left
+                elif event.key == pg.K_LEFT:
+                    self.cursor -= 1
+
+                # move the cursor right
+                elif event.key == pg.K_RIGHT:
+                    self.cursor += 1
+
+                # move the cursor to the beginning of the command
+                elif event.key == pg.K_HOME:
+                    self.cursor = 0
+
+                # move the cursor to the end of the command
+                elif event.key == pg.K_END:
+                    self.cursor = len(self.command)
+
+                # loop through the command history backwards
+                elif event.key == pg.K_UP:
+                    if self.history_index > 0:
+                        self.history_index -= 1
+                        self.command = self.history[self.history_index]
+                        self.cursor = len(self.command)
+
+                # loop through the command history forwards
+                elif event.key == pg.K_DOWN:
+                    if self.history_index < len(self.history) - 1:
+                        self.history_index += 1
+                        self.command = self.history[self.history_index]
+                        self.cursor = len(self.command)
+
+                # submit the command
+                elif event.key == pg.K_RETURN:
+                    self.history.append(self.command)
+                    self.history_index = len(self.history)
+                    self.logger.info(f"Command entered: {self.command}")
+                    self.result = self._execute(self.command)
+                    self._result_changed = True
+                    self.command = ""
+                    self.cursor = 0
+
+                # ignore special keys
+                elif event.key in [
+                    pg.K_BACKQUOTE,
+                    pg.K_LSHIFT,
+                    pg.K_RSHIFT,
+                    pg.K_LCTRL,
+                    pg.K_RCTRL,
+                    pg.K_LALT,
+                    pg.K_RALT,
+                    pg.K_LMETA,
+                    pg.K_RMETA,
+                    pg.K_LSUPER,
+                    pg.K_RSUPER,
+                    pg.K_MODE,
+                    pg.K_HELP,
+                    pg.K_PRINT,
+                    pg.K_SYSREQ,
+                    pg.K_BREAK,
+                    pg.K_MENU,
+                    pg.K_INSERT,
+                    pg.K_CAPSLOCK,
+                ]:
+                    pass
+
+                # add a character to the command
+                elif event.unicode.isprintable():
+                    self.command = self.command[:self.cursor] + event.unicode + self.command[self.cursor:]  # fmt: skip
+                    self.cursor += 1
+
+                else:
+                    self.logger.debug(f"Unhandled key: {event.key}")
+
+        self.cursor = max(0, min(self.cursor, len(self.command)))
+
+    def render(self) -> None:
+        """Render the console."""
+        if not self.visible:
+            return
+
+        self.surface.fill(self.colors["border"])
+        self.command_surface.fill(self.colors["command"])
+
+        # cursor
+        cursor_char = "|" if self.counter % 60 < 30 else "¦"
+
+        # render the command
+        command_with_cursor: str = (
+            self.command[:self.cursor] + cursor_char + self.command[self.cursor:]  # fmt: skip
+        )
+        no_command_text = "Type a command..."
+
+        self.command_surface.blit_text(
+            command_with_cursor if self.command else no_command_text,
+            (0, 0),
+        )
+
+        # render the result
+        if self._result_changed:
+            self._render_result(self.result)
+
+        self.surface.blit(self.command_surface.surface, self.command_surface.pos)
+        self.surface.blit(self.result_surface.surface, self.result_surface.pos)
+
+        simulat.internal_screen.blit(self.surface.surface, self.surface.pos)

--- a/simulat/core/game.py
+++ b/simulat/core/game.py
@@ -85,8 +85,17 @@ class Simulat:
         # initialize topbar
         self._init_topbar()
 
+        # initialize console
+        self._init_console()
+
         # initialize scenes
         self._init_scenes()
+
+    def _init_console(self):
+        """Initialize console."""
+        from simulat.core.console import Console
+
+        self.console = Console()
 
     def _init_topbar(self):
         """Initialize topbar."""
@@ -174,23 +183,38 @@ class Simulat:
             for event in events:
                 if event.type == pg.QUIT:
                     self.running = False
+                if event.type == pg.KEYDOWN:
+                    if event.key == pg.K_BACKQUOTE:
+                        self.console.toggle()
 
             self.internal_screen.fill((30, 30, 30))
 
             if keys[pg.K_ESCAPE]:
                 self.running = False
 
-            for surface in self.focused_surfaces:  # copy to avoid RuntimeError
-                surface.input(
+            # if console is visible, input only goes to console
+            if self.console.visible:
+                self.console.input(
                     events=events,
                     keys=keys,
                     mouse_pos=pg.mouse.get_pos(),
                     mouse_buttons=pg.mouse.get_pressed(),
                 )
+            else:
+                for surface in self.focused_surfaces:
+                    surface.input(
+                        events=events,
+                        keys=keys,
+                        mouse_pos=pg.mouse.get_pos(),
+                        mouse_buttons=pg.mouse.get_pressed(),
+                    )
 
             # UPDATE
             # update scene
             self.scenes[self.active_scene].update(self.frame_delta)
+
+            # update console
+            self.console.update()
 
             # RENDER
             # draw scene
@@ -202,6 +226,9 @@ class Simulat:
             pg.display.set_caption(
                 f"simulat {VERSION} - FPS: {self.clock.get_fps():.2f}"
             )
+
+            # draw console
+            self.console.render()
 
             # update screen
             self.display.blit(

--- a/simulat/core/object.py
+++ b/simulat/core/object.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""Object module for Simulat Framework."""
+
+from __future__ import annotations
+
+import logging as lg
+from typing import Any
+
+
+class Object:
+    """Object class.
+
+    Base class for all objects in simulat.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the object."""
+        self.class_name: str = type(self).__name__
+        self.full_class_name: str = f"{__name__}.{self.class_name}"
+        self.logger = lg.getLogger(self.full_class_name)
+        self.logger.debug(f"Initializing object {self.class_name}...")
+
+        self._input: dict[str, Any] = {
+            "events": [],
+            "keys": {},
+            "mouse_pos": (0, 0),
+            "mouse_buttons": (False, False, False),
+        }
+
+    def input(
+        self,
+        events: list[Any],
+        keys: dict[str, bool],
+        mouse_pos: tuple[int, int],
+        mouse_buttons: tuple[bool, bool, bool],
+    ) -> None:
+        """Update the input for the object."""
+        self._input = {
+            "events": events,
+            "keys": keys,
+            "mouse_pos": mouse_pos,
+            "mouse_buttons": mouse_buttons,
+        }
+
+    def update(self) -> None:
+        """Update the object."""
+        self.logger.warning(
+            f"update method not implemented for {self.full_class_name}."
+        )
+        raise NotImplementedError(f"{self.class_name}.update() method not implemented.")
+
+    def render(self) -> None:
+        """Render the object."""
+        self.logger.warning(
+            f"render method not implemented for {self.full_class_name}."
+        )
+        raise NotImplementedError(f"{self.class_name}.render() method not implemented.")
+
+    def __str__(self) -> str:
+        self.logger.warning(
+            f"__str__ method not implemented for {self.full_class_name}."
+        )
+        return super().__str__()
+
+    def __repr__(self) -> str:
+        self.logger.warning(
+            f"__repr__ method not implemented for {self.full_class_name}."
+        )
+        return super().__repr__()


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [x] `  chore   ` :ticket: chores
- [ ] `refactor` :package: code refactoring
- [ ] `  style   ` :gem: style
- [ ] `   docs   ` :book: documentation changes
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- Adds an `Object` class. An Object class represents every object in simulat, such as a surface, a scene, etc. The class automates some often used calls, such as logging setup.
- Adds a `Console`.

## Related Tickets

- related issue #77 
- closes #

## Instructions, Screenshots

Toggle the console using `backtick` key.

![Console toggling](https://github.com/user-attachments/assets/3b6adabf-0bed-43fc-bc04-47df565cc887)

Use `help` for a list of commands:

![Console help](https://github.com/user-attachments/assets/1f987e42-a315-4d34-86c0-7cedfd7f551d)

Prefix a command with `!` to interpret it (as a python expression).

![Console Interpreting](https://github.com/user-attachments/assets/7eee018b-4470-4a74-90de-e6b31de5d228)

The console can be used to directly interact with the game,
for example limit the FPS:

![Console FPS Limit](https://github.com/user-attachments/assets/50f99191-3e01-4718-8589-6eae022a5dea)

Default globals for the eval mode are:
- `simulat` - the Simulat class,
- `pg` - pygame

